### PR TITLE
[benchmarker] スコアの他にCV数も表示する

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -22,6 +22,7 @@ import (
 type Output struct {
 	Pass     bool     `json:"pass"`
 	Score    int      `json:"score"`
+	CV       int      `json:"cv"`
 	Messages []string `json:"messages"`
 }
 
@@ -137,9 +138,13 @@ func main() {
 	score += 1 * passes.GetCount(passes.LabelOfRequestEstateDocument)
 	score += 1 * passes.GetCount(passes.LabelOfStaticFiles)
 
+	cv := 0
+	cv += passes.GetCount(passes.LabelOfBuyChair)
+	cv += passes.GetCount(passes.LabelOfRequestEstateDocument)
+
 	// application errorは1回で10点減点
 	penalty := 10 * aCnt
-	log.Print(score, penalty)
+	log.Print(score, penalty, cv)
 
 	score -= penalty
 	// 0点以下なら失格
@@ -157,6 +162,7 @@ func main() {
 	output := Output{
 		Pass:     true,
 		Score:    score,
+		CV:       cv,
 		Messages: uniqMsgs(eMsgs),
 	}
 	json.NewEncoder(os.Stdout).Encode(output)


### PR DESCRIPTION
## 目的

- スコアの計算方法として以下の 2 つを検討する (#194)
	- リクエスト成功数の合計
	- CV数 (イスの購入と物件の資料請求) の合計


## 解決方法

- 両方の値をベンチマーカーの出力に含める
	- `score` : リクエスト成功数の合計
	- `cv` : CV数の合計


## 動作確認

- [x] 両方の値が出力されることを確認


## 参考文献 (Optional)

- なし
