### PR TITLE
[benchmarker] botによるクローリングシナリオを追加

### DIFF
--- a/bench/client/client.go
+++ b/bench/client/client.go
@@ -14,6 +14,7 @@ import (
 
 type Client struct {
 	userAgent  string
+	isBot      bool
 	httpClient *http.Client
 }
 

--- a/bench/client/newclient.go
+++ b/bench/client/newclient.go
@@ -8,9 +8,10 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 )
 
-func NewClient(userAgent string) *Client {
+func NewClient(userAgent string, isBot bool) *Client {
 	return &Client{
 		userAgent: userAgent,
+		isBot: isBot,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
@@ -28,6 +29,8 @@ func NewClient(userAgent string) *Client {
 
 func NewClientForInitialize() *Client {
 	return &Client{
+		userAgent: "isucon-initialize",
+		isBot: false,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
@@ -44,6 +47,8 @@ func NewClientForInitialize() *Client {
 
 func NewClientForVerify() *Client {
 	return &Client{
+		userAgent: "isucon-verify",
+		isBot: false,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/bench/client/newclient.go
+++ b/bench/client/newclient.go
@@ -3,26 +3,12 @@ package client
 import (
 	"crypto/tls"
 	"fmt"
-	"math/rand"
 	"net/http"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 )
 
-var clients [paramater.NumOfClient]*Client
-
-func InitializeClients() {
-	for i := 0; i < paramater.NumOfClient; i++ {
-		userAgent := fmt.Sprintf("isucon-%v-user", i)
-		clients[i] = newClient(userAgent)
-	}
-}
-
-func PickClient() *Client {
-	return clients[rand.Intn(len(clients))]
-}
-
-func newClient(userAgent string) *Client {
+func NewClient(userAgent string) *Client {
 	return &Client{
 		userAgent: userAgent,
 		httpClient: &http.Client{

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -80,6 +80,9 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNotFound})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/:id: レスポンスコードが不正です"))
 	}
 
@@ -102,7 +105,9 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 	}
 
 	asset.IncrementChairViewCount(chair.ID)
-	passes.IncrementCount(passes.LabelOfGetChairDetailFromID)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfGetChairDetailFromID)
+	}
 
 	return &chair, nil
 }
@@ -127,6 +132,9 @@ func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*Chai
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/search: レスポンスコードが不正です"))
 	}
 
@@ -140,7 +148,9 @@ func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*Chai
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/search: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfSearchChairsWithQuery)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfSearchChairsWithQuery)
+	}
 
 	return &chairs, nil
 }
@@ -165,6 +175,9 @@ func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*Est
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/search: レスポンスコードが不正です"))
 	}
 
@@ -178,7 +191,9 @@ func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*Est
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/search: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfSearchEstatesWithQuery)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfSearchEstatesWithQuery)
+	}
 
 	return &estates, nil
 }
@@ -208,6 +223,9 @@ func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates)
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("POST /api/estate/nazotte: レスポンスコードが不正です"))
 	}
 
@@ -221,7 +239,9 @@ func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates)
 		return nil, failure.Wrap(err, failure.Message("POST /api/estate/nazotte: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfSearchEstatesNazotte)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfSearchEstatesNazotte)
+	}
 
 	return &estates, nil
 }
@@ -246,6 +266,9 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 
 	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/:id: レスポンスコードが不正です"))
 	}
 
@@ -260,7 +283,9 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 	}
 
 	asset.IncrementEstateViewCount(estate.ID)
-	passes.IncrementCount(passes.LabelOfGetEstateDetailFromID)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfGetEstateDetailFromID)
+	}
 
 	return &estate, nil
 }
@@ -285,6 +310,9 @@ func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, erro
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_chair: レスポンスコードが不正です"))
 	}
 
@@ -298,7 +326,9 @@ func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, erro
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_chair: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfGetRecommendedChair)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfGetRecommendedChair)
+	}
 
 	return &chairs, nil
 }
@@ -323,6 +353,9 @@ func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, er
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate: レスポンスコードが不正です"))
 	}
 
@@ -336,7 +369,9 @@ func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, er
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfGetRecommendedEstate)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfGetRecommendedEstate)
+	}
 
 	return &estate, nil
 }
@@ -361,6 +396,9 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 
 	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
 	if err != nil {
+		if c.isBot {
+			return nil, failure.Translate(err, fails.ErrBot)
+		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate/:id: レスポンスコードが不正です"))
 	}
 
@@ -374,7 +412,9 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate/:id: JSONデコードに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfGetRecommendedEstatesFromChair)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfGetRecommendedEstatesFromChair)
+	}
 
 	return &estate, nil
 }
@@ -399,12 +439,17 @@ func (c *Client) BuyChair(ctx context.Context, id string) error {
 
 	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
+		if c.isBot {
+			return failure.Translate(err, fails.ErrBot)
+		}
 		return failure.Wrap(err, failure.Message("POST /api/chair/buy/:id: リクエストに失敗しました"))
 	}
 
 	intid, _ := strconv.ParseInt(id, 10, 64)
 	asset.DecrementChairStock(intid)
-	passes.IncrementCount(passes.LabelOfBuyChair)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfBuyChair)
+	}
 
 	return nil
 }
@@ -429,10 +474,15 @@ func (c *Client) RequestEstateDocument(ctx context.Context, id string) error {
 
 	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
+		if c.isBot {
+			return failure.Translate(err, fails.ErrBot)
+		}
 		return failure.Wrap(err, failure.Message("POST /api/estate/req_doc/:id: リクエストに失敗しました"))
 	}
 
-	passes.IncrementCount(passes.LabelOfRequestEstateDocument)
+	if !c.isBot {
+		passes.IncrementCount(passes.LabelOfRequestEstateDocument)
+	}
 
 	return nil
 }

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -61,8 +61,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client.InitializeClients()
-
 	// 初期データの準備
 	asset.Initialize(dataDir)
 

--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -30,6 +30,7 @@ const (
 	ErrorOfEstateSearchScenario
 	ErrorOfChairSearchScenario
 	ErrorOfEstateNazotteSearchScenario
+	ErrorOfBotScenario
 )
 
 var (

--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -20,6 +20,8 @@ const (
 	ErrTemporary failure.StringCode = "error temporary"
 	// ErrBenchmarker はベンチマーカ側のエラー。基本的には運営に連絡してもらう
 	ErrBenchmarker failure.StringCode = "error benchmarker"
+	// ErrBot はBotによるリクエストによって発生したエラー。
+	ErrBot failure.StringCode = "error bot"
 )
 
 type ErrorLabel int

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -3,6 +3,7 @@ module github.com/isucon10-qualify/isucon10-qualify/bench
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/morikuni/failure v0.12.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/morikuni/failure v0.12.1 h1:J/Bk9y8834TDUCbETEBUfDGtq3ewk8muGVL/PddrD/M=
 github.com/morikuni/failure v0.12.1/go.mod h1:+IjvKCz9B/D4BQrTzYLwERdWyMkGJdu+q5gri9dWecg=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=

--- a/bench/paramater/paramater.go
+++ b/bench/paramater/paramater.go
@@ -6,7 +6,6 @@ const (
 	NumOfInitialEstateSearchWorker        = 1
 	NumOfInitialChairSearchWorker         = 1
 	NumOfInitialEstateNazotteSearchWorker = 1
-	NumOfClient                           = 10
 	NumOfCheckChairSearchPaging           = 3
 	NumOfCheckEstateSearchPaging          = 3
 	PerPageOfChairSearch                  = 30

--- a/bench/paramater/paramater.go
+++ b/bench/paramater/paramater.go
@@ -6,6 +6,7 @@ const (
 	NumOfInitialEstateSearchWorker        = 1
 	NumOfInitialChairSearchWorker         = 1
 	NumOfInitialEstateNazotteSearchWorker = 1
+	NumOfInitialBotWorker                 = 1
 	NumOfCheckChairSearchPaging           = 3
 	NumOfCheckEstateSearchPaging          = 3
 	PerPageOfChairSearch                  = 30
@@ -16,6 +17,8 @@ const (
 	SleepSwingOnFailScenario              = 1000 // * time.Millisecond
 	SleepTimeOnUserAway                   = 500 * time.Millisecond
 	SleepSwingOnUserAway                  = 100 // * time.Millisecond
+	SleepTimeOnBotInterval                = 500 * time.Millisecond
+	SleepSwingOnBotInterval               = 100 // * time.Millisecond
 	IntervalForCheckWorkers               = 10 * time.Second
 	ThresholdTimeOfAbandonmentPage        = 1 * time.Second
 	DefaultAPITimeout                     = 2000 * time.Millisecond

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -2,15 +2,10 @@ package scenario
 
 import (
 	"context"
-	"math/rand"
-	"net/url"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 )
 
 func botScenario(ctx context.Context, c *client.Client) {
@@ -19,35 +14,8 @@ func botScenario(ctx context.Context, c *client.Client) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		q := url.Values{}
-		q.Set("priceRangeId", strconv.Itoa(rand.Intn(6)))
-		if (rand.Intn(100) % 5) == 0 {
-			q.Set("heightRangeId", strconv.Itoa(rand.Intn(4)))
-		}
-		if (rand.Intn(100) % 5) == 0 {
-			q.Set("widthRangeId", strconv.Itoa(rand.Intn(4)))
-		}
-		if (rand.Intn(100) % 5) == 0 {
-			q.Set("depthRangeId", strconv.Itoa(rand.Intn(4)))
-		}
-
-		if (rand.Intn(100) % 20) == 0 {
-			q.Set("kind", chairKindList[rand.Intn(len(chairKindList))])
-		}
-		if (rand.Intn(100) % 20) == 0 {
-			q.Set("color", chairColorList[rand.Intn(len(chairColorList))])
-		}
-		if (rand.Intn(100) % 20) == 0 {
-			features := make([]string, len(chairFeatureList))
-			copy(features, chairFeatureList)
-			rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-			featureLength := rand.Intn(3) + 1
-			q.Set("features", strings.Join(features[:featureLength], ","))
-		}
-
-		q.Set("perPage", strconv.Itoa(paramater.PerPageOfChairSearch))
-		q.Set("page", "0")
-
+		q := generateRandomQueryForSearchChairs()
+		q.Set("perPage", "10")
 		_, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
@@ -57,24 +25,8 @@ func botScenario(ctx context.Context, c *client.Client) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		q := url.Values{}
-		q.Set("rentRangeId", strconv.Itoa(rand.Intn(4)))
-		if (rand.Intn(100) % 20) == 0 {
-			q.Set("doorHeightRangeId", strconv.Itoa(rand.Intn(4)))
-		}
-		if (rand.Intn(100) % 20) == 0 {
-			q.Set("doorWidthRangeId", strconv.Itoa(rand.Intn(4)))
-		}
-		if (rand.Intn(100) % 20) == 0 {
-			features := make([]string, len(estateFeatureList))
-			copy(features, estateFeatureList)
-			rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-			featureLength := rand.Intn(3) + 1
-			q.Set("features", strings.Join(features[:featureLength], ","))
-		}
-		q.Set("perPage", strconv.Itoa(paramater.PerPageOfEstateSearch))
-		q.Set("page", "0")
-
+		q := generateRandomQueryForSearchEstates()
+		q.Set("perPage", "10")
 		_, err := c.SearchEstatesWithQuery(ctx, q)
 		if err != nil {
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -1,0 +1,88 @@
+package scenario
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+)
+
+func botScenario(ctx context.Context, c *client.Client) {
+	log.Println("bot request start")
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		q := url.Values{}
+		q.Set("priceRangeId", strconv.Itoa(rand.Intn(6)))
+		if (rand.Intn(100) % 5) == 0 {
+			q.Set("heightRangeId", strconv.Itoa(rand.Intn(4)))
+		}
+		if (rand.Intn(100) % 5) == 0 {
+			q.Set("widthRangeId", strconv.Itoa(rand.Intn(4)))
+		}
+		if (rand.Intn(100) % 5) == 0 {
+			q.Set("depthRangeId", strconv.Itoa(rand.Intn(4)))
+		}
+
+		if (rand.Intn(100) % 20) == 0 {
+			q.Set("kind", chairKindList[rand.Intn(len(chairKindList))])
+		}
+		if (rand.Intn(100) % 20) == 0 {
+			q.Set("color", chairColorList[rand.Intn(len(chairColorList))])
+		}
+		if (rand.Intn(100) % 20) == 0 {
+			features := make([]string, len(chairFeatureList))
+			copy(features, chairFeatureList)
+			rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
+			featureLength := rand.Intn(3) + 1
+			q.Set("features", strings.Join(features[:featureLength], ","))
+		}
+
+		q.Set("perPage", strconv.Itoa(paramater.PerPageOfChairSearch))
+		q.Set("page", "0")
+
+		_, err := c.SearchChairsWithQuery(ctx, q)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		q := url.Values{}
+		q.Set("rentRangeId", strconv.Itoa(rand.Intn(4)))
+		if (rand.Intn(100) % 20) == 0 {
+			q.Set("doorHeightRangeId", strconv.Itoa(rand.Intn(4)))
+		}
+		if (rand.Intn(100) % 20) == 0 {
+			q.Set("doorWidthRangeId", strconv.Itoa(rand.Intn(4)))
+		}
+		if (rand.Intn(100) % 20) == 0 {
+			features := make([]string, len(estateFeatureList))
+			copy(features, estateFeatureList)
+			rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
+			featureLength := rand.Intn(3) + 1
+			q.Set("features", strings.Join(features[:featureLength], ","))
+		}
+		q.Set("perPage", strconv.Itoa(paramater.PerPageOfEstateSearch))
+		q.Set("page", "0")
+
+		_, err := c.SearchEstatesWithQuery(ctx, q)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+		}
+	}()
+
+	wg.Wait()
+	log.Println("bot request end")
+}

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -2,7 +2,6 @@ package scenario
 
 import (
 	"context"
-	"log"
 	"math/rand"
 	"net/url"
 	"strconv"
@@ -15,7 +14,6 @@ import (
 )
 
 func botScenario(ctx context.Context, c *client.Client) {
-	log.Println("bot request start")
 	wg := sync.WaitGroup{}
 
 	wg.Add(1)
@@ -84,5 +82,4 @@ func botScenario(ctx context.Context, c *client.Client) {
 	}()
 
 	wg.Wait()
-	log.Println("bot request end")
 }

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
+	"github.com/morikuni/failure"
 )
 
 func botScenario(ctx context.Context, c *client.Client) {
@@ -18,7 +19,11 @@ func botScenario(ctx context.Context, c *client.Client) {
 		q.Set("perPage", "10")
 		_, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			code, _ := failure.CodeOf(err)
+			if code != fails.ErrBot {
+				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			}
+			return
 		}
 	}()
 
@@ -29,7 +34,11 @@ func botScenario(ctx context.Context, c *client.Client) {
 		q.Set("perPage", "10")
 		_, err := c.SearchEstatesWithQuery(ctx, q)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			code, _ := failure.CodeOf(err)
+			if code != fails.ErrBot {
+				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			}
+			return
 		}
 	}()
 

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -2,6 +2,7 @@ package scenario
 
 import (
 	"context"
+	"strconv"
 	"sync"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
@@ -17,13 +18,25 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q := generateRandomQueryForSearchChairs()
 		q.Set("perPage", "10")
-		_, err := c.SearchChairsWithQuery(ctx, q)
+		chairs, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
 			}
 			return
+		}
+
+		for _, chair := range chairs.Chairs {
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				_, err := c.GetChairDetailFromID(ctx, id)
+				code, _ := failure.CodeOf(err)
+				if code != fails.ErrBot {
+					fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+				}
+			}(strconv.FormatInt(chair.ID, 10))
 		}
 	}()
 
@@ -32,13 +45,25 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q := generateRandomQueryForSearchEstates()
 		q.Set("perPage", "10")
-		_, err := c.SearchEstatesWithQuery(ctx, q)
+		estates, err := c.SearchEstatesWithQuery(ctx, q)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
 			}
 			return
+		}
+
+		for _, estate := range estates.Estates {
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				_, err := c.GetEstateDetailFromID(ctx, id)
+				code, _ := failure.CodeOf(err)
+				if code != fails.ErrBot {
+					fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+				}
+			}(strconv.FormatInt(estate.ID, 10))
 		}
 	}()
 

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -47,9 +47,7 @@ var chairFeatureList = []string{
 	"フットレスト",
 }
 
-func chairSearchScenario(ctx context.Context) error {
-	var c *client.Client = client.PickClient()
-
+func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	err := c.AccessTopPage(ctx)
 	if err != nil {

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -47,28 +47,7 @@ var chairFeatureList = []string{
 	"フットレスト",
 }
 
-func chairSearchScenario(ctx context.Context, c *client.Client) error {
-	t := time.Now()
-	err := c.AccessTopPage(ctx)
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
-	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
-		return failure.New(fails.ErrTimeout)
-	}
-
-	t = time.Now()
-	err = c.AccessChairSearchPage(ctx)
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
-	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
-		return failure.New(fails.ErrTimeout)
-	}
-
-	// Search Chairs with Query
+func generateRandomQueryForSearchChairs() url.Values {
 	q := url.Values{}
 	q.Set("priceRangeId", strconv.Itoa(rand.Intn(6)))
 	if (rand.Intn(100) % 5) == 0 {
@@ -97,6 +76,33 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 	q.Set("perPage", strconv.Itoa(paramater.PerPageOfChairSearch))
 	q.Set("page", "0")
+
+	return q
+}
+
+func chairSearchScenario(ctx context.Context, c *client.Client) error {
+	t := time.Now()
+	err := c.AccessTopPage(ctx)
+	if err != nil {
+		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		return failure.New(fails.ErrApplication)
+	}
+	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+		return failure.New(fails.ErrTimeout)
+	}
+
+	t = time.Now()
+	err = c.AccessChairSearchPage(ctx)
+	if err != nil {
+		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		return failure.New(fails.ErrApplication)
+	}
+	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+		return failure.New(fails.ErrTimeout)
+	}
+
+	// Search Chairs with Query
+	q := generateRandomQueryForSearchChairs()
 
 	t = time.Now()
 	cr, err := c.SearchChairsWithQuery(ctx, q)

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -119,9 +119,7 @@ func getBoundingBox(points []point) [2]point {
 	return boundingBox
 }
 
-func estateNazotteSearchScenario(ctx context.Context) error {
-	var c *client.Client = client.PickClient()
-
+func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	err := c.AccessTopPage(ctx)
 	if err != nil {

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -22,6 +22,28 @@ var estateFeatureList = []string{
 	"ペット飼育可能",
 }
 
+func generateRandomQueryForSearchEstates() url.Values {
+	q := url.Values{}
+	q.Set("rentRangeId", strconv.Itoa(rand.Intn(4)))
+	if (rand.Intn(100) % 20) == 0 {
+		q.Set("doorHeightRangeId", strconv.Itoa(rand.Intn(4)))
+	}
+	if (rand.Intn(100) % 20) == 0 {
+		q.Set("doorWidthRangeId", strconv.Itoa(rand.Intn(4)))
+	}
+	if (rand.Intn(100) % 20) == 0 {
+		features := make([]string, len(estateFeatureList))
+		copy(features, estateFeatureList)
+		rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
+		featureLength := rand.Intn(3) + 1
+		q.Set("features", strings.Join(features[:featureLength], ","))
+	}
+	q.Set("perPage", strconv.Itoa(paramater.PerPageOfEstateSearch))
+	q.Set("page", "0")
+
+	return q
+}
+
 func estateSearchScenario(ctx context.Context, c *client.Client) error {
 
 	t := time.Now()
@@ -45,23 +67,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	// Search Estates with Query
-	q := url.Values{}
-	q.Set("rentRangeId", strconv.Itoa(rand.Intn(4)))
-	if (rand.Intn(100) % 20) == 0 {
-		q.Set("doorHeightRangeId", strconv.Itoa(rand.Intn(4)))
-	}
-	if (rand.Intn(100) % 20) == 0 {
-		q.Set("doorWidthRangeId", strconv.Itoa(rand.Intn(4)))
-	}
-	if (rand.Intn(100) % 20) == 0 {
-		features := make([]string, len(estateFeatureList))
-		copy(features, estateFeatureList)
-		rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-		featureLength := rand.Intn(3) + 1
-		q.Set("features", strings.Join(features[:featureLength], ","))
-	}
-	q.Set("perPage", strconv.Itoa(paramater.PerPageOfEstateSearch))
-	q.Set("page", "0")
+	q := generateRandomQueryForSearchEstates()
 
 	t = time.Now()
 	er, err := c.SearchEstatesWithQuery(ctx, q)

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -22,8 +22,7 @@ var estateFeatureList = []string{
 	"ペット飼育可能",
 }
 
-func estateSearchScenario(ctx context.Context) error {
-	var c *client.Client = client.PickClient()
+func estateSearchScenario(ctx context.Context, c *client.Client) error {
 
 	t := time.Now()
 	err := c.AccessTopPage(ctx)

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -2,16 +2,22 @@ package scenario
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"math/rand"
 	"time"
 
+	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 	"github.com/morikuni/failure"
+	"github.com/google/uuid"
 )
 
 func runEstateSearchWorker(ctx context.Context) {
+	u, _ := uuid.NewRandom()
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+
 	for {
 		r := rand.Intn(100)
 		t := time.NewTimer(time.Duration(r) * time.Millisecond)
@@ -21,7 +27,7 @@ func runEstateSearchWorker(ctx context.Context) {
 			t.Stop()
 			return
 		}
-		err := estateSearchScenario(ctx)
+		err := estateSearchScenario(ctx, c)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {
@@ -44,6 +50,9 @@ func runEstateSearchWorker(ctx context.Context) {
 }
 
 func runChairSearchWorker(ctx context.Context) {
+	u, _ := uuid.NewRandom()
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+
 	for {
 		r := rand.Intn(100)
 		t := time.NewTimer(time.Duration(r) * time.Millisecond)
@@ -53,7 +62,7 @@ func runChairSearchWorker(ctx context.Context) {
 			t.Stop()
 			return
 		}
-		err := chairSearchScenario(ctx)
+		err := chairSearchScenario(ctx, c)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {
@@ -76,6 +85,9 @@ func runChairSearchWorker(ctx context.Context) {
 }
 
 func runEstateNazotteSearchWorker(ctx context.Context) {
+	u, _ := uuid.NewRandom()
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+
 	for {
 		r := rand.Intn(100)
 		t := time.NewTimer(time.Duration(r) * time.Millisecond)
@@ -85,7 +97,7 @@ func runEstateNazotteSearchWorker(ctx context.Context) {
 			t.Stop()
 			return
 		}
-		err := estateNazotteSearchScenario(ctx)
+		err := estateNazotteSearchScenario(ctx, c)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -16,7 +16,7 @@ import (
 
 func runEstateSearchWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
-	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()), false)
 
 	for {
 		r := rand.Intn(100)
@@ -51,7 +51,7 @@ func runEstateSearchWorker(ctx context.Context) {
 
 func runChairSearchWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
-	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()), false)
 
 	for {
 		r := rand.Intn(100)
@@ -86,7 +86,7 @@ func runChairSearchWorker(ctx context.Context) {
 
 func runEstateNazotteSearchWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
-	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()))
+	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()), false)
 
 	for {
 		r := rand.Intn(100)
@@ -121,7 +121,7 @@ func runEstateNazotteSearchWorker(ctx context.Context) {
 
 func runBotWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
-	c := client.NewClient(fmt.Sprintf("isucon-bot-%v", u.String()))
+	c := client.NewClient(fmt.Sprintf("isucon-bot-%v", u.String()), false)
 
 	for {
 		go botScenario(ctx, c)

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -121,7 +121,7 @@ func runEstateNazotteSearchWorker(ctx context.Context) {
 
 func runBotWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
-	c := client.NewClient(fmt.Sprintf("isucon-bot-%v", u.String()), false)
+	c := client.NewClient(fmt.Sprintf("isucon-bot-%v", u.String()), true)
 
 	for {
 		go botScenario(ctx, c)

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -119,6 +119,24 @@ func runEstateNazotteSearchWorker(ctx context.Context) {
 	}
 }
 
+func runBotWorker(ctx context.Context) {
+	u, _ := uuid.NewRandom()
+	c := client.NewClient(fmt.Sprintf("isucon-bot-%v", u.String()))
+
+	for {
+		go botScenario(ctx, c)
+		r := rand.Intn(paramater.SleepSwingOnBotInterval) - paramater.SleepSwingOnBotInterval*0.5
+		s := paramater.SleepTimeOnBotInterval + time.Duration(r)*time.Millisecond
+		t := time.NewTimer(s)
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			t.Stop()
+			return
+		}
+	}
+}
+
 func checkWorkers(ctx context.Context) {
 	t := time.NewTicker(paramater.IntervalForCheckWorkers)
 	for {
@@ -158,6 +176,11 @@ func Load(ctx context.Context) {
 	// なぞって検索をするシナリオ
 	for i := 0; i < paramater.NumOfInitialEstateNazotteSearchWorker; i++ {
 		go runEstateNazotteSearchWorker(ctx)
+	}
+
+	// ボットによる検索シナリオ
+	for i := 0; i < paramater.NumOfInitialBotWorker; i++ {
+		go runBotWorker(ctx)
 	}
 
 	go checkWorkers(ctx)


### PR DESCRIPTION
## 目的

- bot からのアクセスにより、サーバーへの負荷を上昇させたい
- これを表現するためのシナリオを追加した


## 解決方法

- bot によるクローリングシナリオを追加
	- 500 ms に 1 回、以下のシナリオを実行する
	- イス・物件の検索を行う
	- 検索結果の上位 10 件に対して、詳細取得を行う
	- 検索の response が 200 以外だったらその場で中断される


## 動作確認

- [x] bot からのアクセスが定期的に投げられていることを確認
- [x] bot からのリクエストが成功してもスコアが上昇しないことを確認


## 参考文献 (Optional)

- なし
