### PR TITLE
[benchmarker] assetのInitializeを高速化する

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -64,12 +64,25 @@ func main() {
 	client.InitializeClients()
 
 	// 初期データの準備
-	asset.Initialize(dataDir)
+	asset.Initialize(context.Background(), dataDir)
+	eMsgs := fails.ErrorsForCheck.GetMsgs()
+	if len(eMsgs) > 0 {
+		log.Print("asset initialize failed")
+
+		output := Output{
+			Pass:     false,
+			Score:    0,
+			Messages: eMsgs,
+		}
+		json.NewEncoder(os.Stdout).Encode(output)
+
+		return
+	}
 
 	log.Print("=== initialize ===")
 	// 初期化：/initialize にリクエストを送ることで、外部リソースのURLを指定する・DBのデータを初期データのみにする
 	scenario.Initialize(context.Background())
-	eMsgs := fails.ErrorsForCheck.GetMsgs()
+	eMsgs = fails.ErrorsForCheck.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("initialize failed")
 


### PR DESCRIPTION
## 目的

- データ件数が増えれば増えるほど `asset.Initialize` に掛かる時間が膨大になっていた


## 解決方法

- イスと物件の `asset` の初期化を直列で処理していたので、 goroutine を用いた
- `json.Unmarshal()` を `json.NewDecoder().Decode()` で置き換えた


## 動作確認

- [x] `asset.Initialize` が正常に動作することを確認
	- イス・物件のダミーデータをそれぞれ `10 ** 6` 件にしたときの変更前後の `asset.Initialize` に掛かる時間を 3 回ずつ計測した
	- 変更前: `38s` , `39s` , `37s` (mean: `38s` )
	- 変更後: `16s` , `16s` , `15s` (mean: `16s` )


## 参考文献 (Optional)

- http://kudohamu.hatenablog.com/entry/2014/11/05/165133
