### PR TITLE
[webapp/go] GET /initializeでは、削除された行を追加し閲覧数や在庫数を初期値に戻す

### DIFF
--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -8,11 +8,11 @@ refresh_estate_data:
 
 chair_data: make_chair_data.py
 	python3 make_chair_data.py
-	cp result/2_DummyChairData.sql ../webapp/mysql/db/2_DummyChairData.sql
+	cp result/chairData.csv ../webapp/mysql/files/chairData.csv
 
 estate_data: make_estate_data.py
 	python3 make_estate_data.py
-	cp result/1_DummyEstateData.sql ../webapp/mysql/db/1_DummyEstateData.sql
+	cp result/estateData.csv ../webapp/mysql/files/estateData.csv
 
 verification_data: ./make_verification_data
 	rm -rf ./result/verification_data

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -11,18 +11,16 @@ Faker.seed(19700101)
 random.seed(19700101)
 
 DESCRIPTION_LINES_FILE = "./description.txt"
-OUTPUT_SQL_FILE = "./result/2_DummyChairData.sql"
+OUTPUT_CSV_FILE = "./result/chairData.csv"
 OUTPUT_TXT_FILE = "./result/chair_json.txt"
 CHAIR_IMAGE_ORIGIN_DIR = "./origin/chair"
 CHAIR_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/chair"
 CHAIR_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
-BULK_INSERT_COUNT = 500
 CHAIR_MIN_CENTIMETER = 30
 CHAIR_MAX_CENTIMETER = 200
 MIN_VIEW_COUNT = 3000
 MAX_VIEW_COUNT = 1000000
-sqlCommands = "use isuumo;\n"
 
 CHAIR_COLOR_LIST = [
     "黒",
@@ -110,6 +108,11 @@ def read_src_file_data(file_path):
         return img.read()
 
 
+def dump_chair_to_csv_str(chair):
+    # id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind
+    return f"{chair['id']},\"{chair['thumbnail']}\",\"{chair['name']}\",{chair['price']},{chair['height']},{chair['width']},{chair['depth']},{chair['view_count']},{chair['stock']},\"{chair['color']}\",\"{chair['description']}\",\"{chair['features']}\",\"{chair['kind']}\""
+
+
 def dump_chair_to_json_str(chair):
     return json.dumps({
         "id": chair["id"],
@@ -166,14 +169,7 @@ if __name__ == "__main__":
     with open(DESCRIPTION_LINES_FILE, mode='r', encoding='utf-8') as description_lines:
         desc_lines = description_lines.readlines()
 
-    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
-        sqlfile.write(sqlCommands)
-        if RECORD_COUNT % BULK_INSERT_COUNT != 0:
-            raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
-                RECORD_COUNT, BULK_INSERT_COUNT))
-
-        chair_id = 1
-
+    with open(OUTPUT_CSV_FILE, mode='w', encoding='utf-8') as csvfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
         CHAIRS_FOR_VERIFY = [
             # 購入された際に在庫が減ることを検証するためのデータ
             generate_chair_dummy_data(1, {
@@ -193,19 +189,12 @@ if __name__ == "__main__":
             })
         ]
 
-        sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
-        sqlfile.write(sqlCommand)
-        txtfile.write(
-            "\n".join([dump_chair_to_json_str(chair) for chair in CHAIRS_FOR_VERIFY]) + "\n")
+        chairs = CHAIRS_FOR_VERIFY + \
+            [generate_chair_dummy_data(len(CHAIRS_FOR_VERIFY) + i + 1)
+             for i in range(RECORD_COUNT)]
 
-        chair_id += len(CHAIRS_FOR_VERIFY)
+        csvfile.write(
+            "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
 
-        for _ in range(RECORD_COUNT // BULK_INSERT_COUNT):
-            bulk_list = [generate_chair_dummy_data(
-                chair_id + i) for i in range(BULK_INSERT_COUNT)]
-            chair_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
-            sqlfile.write(sqlCommand)
-
-            txtfile.write(
-                "\n".join([dump_chair_to_json_str(chair) for chair in bulk_list]) + "\n")
+        txtfile.write("\n".join([dump_chair_to_json_str(chair)
+                                 for chair in chairs]) + "\n")

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -15,6 +15,7 @@ OUTPUT_CSV_FILE = "./result/chairData.csv"
 OUTPUT_TXT_FILE = "./result/chair_json.txt"
 CHAIR_IMAGE_ORIGIN_DIR = "./origin/chair"
 CHAIR_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/chair"
+CSV_COLUMNS_ORDER = "id,thumbnail,name,price,height,width,depth,view_count,stock,color,description,features,kind\n"
 CHAIR_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
 CHAIR_MIN_CENTIMETER = 30
@@ -194,7 +195,7 @@ if __name__ == "__main__":
              for i in range(RECORD_COUNT)]
 
         csvfile.write(
-            "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
+            CSV_COLUMNS_ORDER + "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
 
         txtfile.write("\n".join([dump_chair_to_json_str(chair)
                                  for chair in chairs]) + "\n")

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -15,6 +15,7 @@ OUTPUT_CSV_FILE = "./result/estateData.csv"
 OUTPUT_TXT_FILE = "./result/estate_json.txt"
 ESTATE_IMAGE_ORIGIN_DIR = "./origin/estate"
 ESTATE_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/estate"
+CSV_COLUMNS_ORDER = "id,thumbnail,name,latitude,longitude,address,rent,door_height,door_width,view_count,description,features\n"
 ESTATE_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
 DOOR_MIN_CENTIMETER = 30
@@ -122,7 +123,7 @@ if __name__ == '__main__':
              for i in range(RECORD_COUNT)]
 
         csvfile.write(
-            "\n".join([dump_estate_to_csv_str(estate) for estate in estates]))
+            CSV_COLUMNS_ORDER + "\n".join([dump_estate_to_csv_str(estate) for estate in estates]))
 
         txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                  for estate in estates]) + "\n")

--- a/webapp/docker-compose.yaml
+++ b/webapp/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ./mysql/data:/var/lib/mysql
       - ./mysql/db:/docker-entrypoint-initdb.d
+      - ./mysql/files:/var/lib/mysql-files
       - ./logs/mysql:/var/log/mysql
       - ../provisioning/ansible/roles/web/files/my.cnf:/etc/mysql/conf.d/my.cnf
       - ../provisioning/ansible/roles/web/files/slow-mysqld.cnf:/etc/mysql/conf.d/slowquery.cnf

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -433,8 +433,8 @@ func initialize(c echo.Context) error {
 	fpathprefix := filepath.Join("..", "mysql", "db")
 	paths := []string{
 		filepath.Join(fpathprefix, "0_Schema.sql"),
-		filepath.Join(fpathprefix, "1_DummyEstateData.sql"),
-		filepath.Join(fpathprefix, "2_DummyChairData.sql"),
+		// filepath.Join(fpathprefix, "1_DummyEstateData.sql"),
+		// filepath.Join(fpathprefix, "2_DummyChairData.sql"),
 	}
 
 	for _, p := range paths {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -431,12 +431,13 @@ func main() {
 }
 
 func cleanup(c echo.Context) error {
+	MySQLFilePath, _ := filepath.Abs(filepath.Join("..", "mysql", "db", "0_Schema.sql"))
 	cmdstr := fmt.Sprintf("mysql -h %v -u %v -p%v %v < %v",
 		MySQLConnectionData.Host,
 		MySQLConnectionData.User,
 		MySQLConnectionData.Password,
 		MySQLConnectionData.DBName,
-		filepath.Abs(filepath.Join("..", "mysql", "db", "0_Schema.sql")),
+		MySQLFilePath,
 	)
 	if err := exec.Command("bash", "-c", cmdstr).Run(); err != nil {
 		c.Logger().Errorf("Cleanup script error : %v", err)

--- a/webapp/mysql/.gitignore
+++ b/webapp/mysql/.gitignore
@@ -1,5 +1,3 @@
-db/1_DummyEstateData.sql
-db/2_DummyChairData.sql
 data
 files/*
 !files/.gitkeep

--- a/webapp/mysql/.gitignore
+++ b/webapp/mysql/.gitignore
@@ -1,3 +1,5 @@
 db/1_DummyEstateData.sql
 db/2_DummyChairData.sql
 data
+files/*
+!files/.gitkeep

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -37,5 +37,5 @@ CREATE TABLE chair (
     `kind` VARCHAR(64) NOT NULL
 )ENGINE=InnoDB;
 
-LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
-LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -36,3 +36,6 @@ CREATE TABLE chair (
     `features` VARCHAR(64) NOT NULL,
     `kind` VARCHAR(64) NOT NULL
 )ENGINE=InnoDB;
+
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);

--- a/webapp/mysql/db/1_Initialize.sql
+++ b/webapp/mysql/db/1_Initialize.sql
@@ -1,0 +1,7 @@
+USE isuumo;
+
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' IGNORE INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' IGNORE INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);
+
+UPDATE chair SET view_count = 10000, stock = 2;
+UPDATE estate SET view_count = 10000;


### PR DESCRIPTION
## 目的

- #5 にてスピードは改善されたが、 10 ** 6 件より増やした場合に 2 分を超えてしまう
- テーブルを drop してからの全件 insert をやめることにした


## 解決方法

- `GET /initialize` では、削除された行を追加し閲覧数や在庫数を初期値に戻すように変更
- `GET /cleanup` では、従来のようにテーブルを drop してから全件を insert するようにしている
- ただし、現状の変更は Verify 用のダミーデータにも影響が及んでいるため、ベンチマーカーの Verify は失敗する


## 動作確認

- [x] `GET /cleanup` してからの `GET /initialize` が高速化されているかを確認
	- イス・物件のダミーデータをそれぞれ 10 ** 6 件にしたときの変更前後の GET /initialize に掛かる時間を 3 回ずつ計測した
	- #5 : `139s` , `139s` , `139s` (mean: `139s` )
	- #7 : `80s` , `84s` , `82s` (mean: `82s` )


## 参考文献 (Optional)

- [LOAD DATA INFILE (IGNOREオプション)](https://variable.jp/2009/11/07/load-data-infile-ignore%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3/)
