### PR TITLE
[bench] エラーメッセージの修正

### DIFF
--- a/bench/client/browse.go
+++ b/bench/client/browse.go
@@ -19,7 +19,7 @@ import (
 func (c *Client) fetch(ctx context.Context, resource string, dst io.Writer) error {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, resource)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("Initialize client.newGetRequest error occured"))
+		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -28,7 +28,7 @@ type Coordinate struct {
 func (c *Client) Initialize(ctx context.Context) error {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/initialize")
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("Initialize client.newGetRequest error occured"))
+		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	// T/O付きのコンテキストが入る
@@ -63,7 +63,7 @@ type EstatesResponse struct {
 func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Chair, error) {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/api/chair/"+id)
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("GetChairDerailFromID client.newGetRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -115,7 +115,7 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*ChairsResponse, error) {
 	req, err := c.newGetRequestWithQuery(ShareTargetURLs.AppURL, "/api/chair/search", q)
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("SearchChairsWithQuery client.newGetRequestWithQuery error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -158,7 +158,7 @@ func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*Chai
 func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*EstatesResponse, error) {
 	req, err := c.newGetRequestWithQuery(ShareTargetURLs.AppURL, "/api/estate/search", q)
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("SearchEstatesWithQuery client.newGetRequestWithQuery error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -201,12 +201,12 @@ func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*Est
 func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates) (*EstatesResponse, error) {
 	b, err := json.Marshal(polygon)
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("SearchEstatesNazotte json.Marshal error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/estate/nazotte", bytes.NewBuffer(b))
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("SearchEstatesNazotte client.newPostRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -249,7 +249,7 @@ func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates)
 func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.Estate, error) {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/api/estate/"+id)
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("GetEstateDetailFromID client.newGetRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -293,7 +293,7 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, error) {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/api/recommended_chair")
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("GetRecommendedChair client.newGetRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -336,7 +336,7 @@ func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, erro
 func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, error) {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/api/recommended_estate")
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("GetRecommendedEstate client.newGetRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -379,7 +379,7 @@ func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, er
 func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (*EstatesResponse, error) {
 	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/api/recommended_estate/"+strconv.FormatInt(id, 10))
 	if err != nil {
-		return nil, failure.Translate(err, fails.ErrBenchmarker, failure.Message("GetRecommendedEstatesFromChair client.newGetRequest error occured"))
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -422,7 +422,7 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 func (c *Client) BuyChair(ctx context.Context, id string) error {
 	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/chair/buy/"+id, nil)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("BuyChair client.newPostRequest error occured"))
+		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)
@@ -457,7 +457,7 @@ func (c *Client) BuyChair(ctx context.Context, id string) error {
 func (c *Client) RequestEstateDocument(ctx context.Context, id string) error {
 	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/estate/req_doc/"+id, nil)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("RequestEstateDocument client.newPostRequest error occured"))
+		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	req = req.WithContext(ctx)

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -147,7 +147,7 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK, http.StatusNoContent:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスの検索結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"))
 		}
 
 		var expected *client.ChairsResponse

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -147,7 +147,7 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK, http.StatusNoContent:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスの検索結果が不正です"))
 		}
 
 		var expected *client.ChairsResponse
@@ -157,12 +157,12 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 		}
 
 		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"))
 		}
 	}
 
@@ -228,7 +228,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		var expected *client.EstatesResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 		if !reflect.DeepEqual(expected, actual) {
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"))

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -162,7 +162,7 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: 物件のおすすめ結果が不正です"))
 		}
 	}
 
@@ -205,16 +205,16 @@ func verifyRecommendedEstate(ctx context.Context, c *client.Client, filePath str
 func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, filePath string) error {
 	snapshot, err := loadSnapshotFromFile(filePath)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate: Snapshotの読み込みに失敗しました"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: Snapshotの読み込みに失敗しました"))
 	}
 
 	idx := strings.LastIndex(snapshot.Request.Resource, "/")
 	if idx == -1 || idx == len(snapshot.Request.Resource)-1 {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: 不正なSnapshotです"))
 	}
 	id, err := strconv.ParseInt(string([]rune(snapshot.Request.Resource)[idx+1:]), 10, 64)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: 不正なSnapshotです"))
 	}
 
 	actual, err := c.GetRecommendedEstatesFromChair(ctx, id)
@@ -260,7 +260,7 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK, http.StatusNoContent:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件のおすすめ結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
 		}
 
 		var expected *client.EstatesResponse
@@ -270,12 +270,12 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 		}
 
 		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
 		}
 	}
 


### PR DESCRIPTION
## 目的

- 競技者の誤解を招くエラーメッセージが何点かあった


## 解決方法

- エラーメッセージに含まれる path や内容を修正


## 動作確認

- [x] ベンチマーカーが動作することを確認


## 参考文献 (Optional)

- なし
