### PR TITLE
[webapp/go] なぞって検索の結果が0件の際は、必ずhttp.StatusNoContentを返す

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1024,6 +1024,10 @@ func searchEstateNazotte(c echo.Context) error {
 		}
 	}
 
+	if len(estatesInPolygon) == 0 {
+		return c.JSON(http.StatusNoContent, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+	}
+
 	var re EstateSearchResponse
 	re.Estates = []*Estate{}
 	for i, estate := range estatesInPolygon {


### PR DESCRIPTION
## 目的

- なぞって検索の結果が 0 件でも、ステータスコードは `http.StatusOK` か `http.StatusNoContent` のどちらかだった


## 解決方法

- 検索結果が 0 件の場合は `http.StatusNoContent` を返すようにした


## 動作確認

- [x] ベンチマーカーが正常に動作することを確認


## 参考文献 (Optional)

- なし
