### PR TITLE
[webapp/go] レスポンスのステータスにhttp.StatusNoContentを使わない

### DIFF
--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -130,7 +130,7 @@ func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*Chai
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)
@@ -173,7 +173,7 @@ func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*Est
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)
@@ -221,7 +221,7 @@ func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates)
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)
@@ -308,7 +308,7 @@ func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, erro
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)
@@ -351,7 +351,7 @@ func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, er
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)
@@ -394,7 +394,7 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
 
-	err = checkStatusCode(res, []int{http.StatusOK, http.StatusNoContent})
+	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
 		if c.isBot {
 			return nil, failure.Translate(err, fails.ErrBot)

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -74,7 +74,7 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 	actual, err := c.SearchChairsWithQuery(ctx, q)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"))
 		}
@@ -112,7 +112,7 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 	actual, err := c.SearchEstatesWithQuery(ctx, q)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
 		}
@@ -145,7 +145,7 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 	actual, err := c.GetRecommendedChair(ctx)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"))
 		}
@@ -178,7 +178,7 @@ func verifyRecommendedEstate(ctx context.Context, c *client.Client, filePath str
 	actual, err := c.GetRecommendedEstate(ctx)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"))
 		}
@@ -220,7 +220,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 	actual, err := c.GetRecommendedEstatesFromChair(ctx, id)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"))
 		}
@@ -258,7 +258,7 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 	actual, err := c.SearchEstatesNazotte(ctx, coordinates)
 
 	switch snapshot.Response.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
+	case http.StatusOK:
 		if err != nil {
 			return failure.Translate(err, fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
 		}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -634,7 +634,7 @@ func searchChairs(c echo.Context) error {
 	err = db.Select(&searchedchairs, sqlstr+searchCondition+limitOffset, queryParams...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusNoContent, ChairSearchResponse{Count: 0, Chairs: []*Chair{}})
+			return c.JSON(http.StatusOK, ChairSearchResponse{Count: 0, Chairs: []*Chair{}})
 		}
 		c.Logger().Errorf("searchChairs DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -720,7 +720,7 @@ func searchRecommendChair(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.Logger().Error("searchRecommendChair not found")
-			return c.JSON(http.StatusNoContent, ChairRecommendResponse{[]*Chair{}})
+			return c.JSON(http.StatusOK, ChairRecommendResponse{[]*Chair{}})
 		}
 		c.Logger().Errorf("searchRecommendChair DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -898,7 +898,7 @@ func searchEstates(c echo.Context) error {
 	err = db.Select(&matchestates, sqlstr+searchQuery+limitOffset, searchQueryParameter...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusNoContent, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+			return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
 		}
 		c.Logger().Errorf("searchEstates DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -920,7 +920,7 @@ func searchRecommendEstate(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.Logger().Error("searchRecommendEstate not found")
-			return c.JSON(http.StatusNoContent, EstateRecommendResponse{[]*Estate{}})
+			return c.JSON(http.StatusOK, EstateRecommendResponse{[]*Estate{}})
 		}
 		c.Logger().Errorf("searchRecommendEstate DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -962,7 +962,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 	err = db.Select(&recommendEstates, sqlstr, w, h, w, d, h, w, h, d, d, w, d, h, LIMIT)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusNoContent, EstateRecommendResponse{[]*Estate{}})
+			return c.JSON(http.StatusOK, EstateRecommendResponse{[]*Estate{}})
 		}
 		c.Logger().Errorf("Database execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -997,7 +997,7 @@ func searchEstateNazotte(c echo.Context) error {
 	err = db.Select(&estatesInBoundingBox, sqlstr, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {
 		c.Echo().Logger.Infof("select * from estate where latitude ...", err)
-		return c.JSON(http.StatusNoContent, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+		return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
 	} else if err != nil {
 		c.Echo().Logger.Errorf("database execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -1025,7 +1025,7 @@ func searchEstateNazotte(c echo.Context) error {
 	}
 
 	if len(estatesInPolygon) == 0 {
-		return c.JSON(http.StatusNoContent, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+		return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
 	}
 
 	var re EstateSearchResponse

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1024,10 +1024,6 @@ func searchEstateNazotte(c echo.Context) error {
 		}
 	}
 
-	if len(estatesInPolygon) == 0 {
-		return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
-	}
-
 	var re EstateSearchResponse
 	re.Estates = []*Estate{}
 	for i, estate := range estatesInPolygon {


### PR DESCRIPTION
## 目的

- `echo.Context.JSON` は第一引数に `http.StatusNoContent` が入るとレスポンスボディが空文字列になってしまう
	- Ref. https://golang.org/src/net/http/transfer.go?h=bodyAllowedForStatus#L445
- そもそも [`204`](https://developer.mozilla.org/ja/docs/Web/HTTP/Status/204) はレスポンスボディが空であるべきで、 JSON を返すべきではない


## 解決方法

- `http.StatusNoContent` を返さない


## 動作確認

- [x] ベンチマーカーが正常に動作することを確認


## 参考文献 (Optional)

- なし
