### PR TITLE
[webapp/go] echo-pprofを削除

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 	"github.com/labstack/gommon/log"
-	echopprof "github.com/sevenNt/echo-pprof"
 )
 
 const SRID = 6668
@@ -411,9 +410,6 @@ func main() {
 	e.GET("/api/recommended_estate", searchRecommendEstate)
 	e.GET("/api/recommended_estate/:id", searchRecommendEstateWithChair)
 	e.GET("/api/recommended_chair", searchRecommendChair)
-
-	// pprof
-	echopprof.Wrap(e)
 
 	MySQLConnectionData = NewMySQLConnectionEnv()
 


### PR DESCRIPTION
## 目的

- `webapp/go` に `echo-pprof` が入ったまんまだった


## 解決方法

- `echo-pprof` を削除した


## 動作確認

- [x] webapp/go がビルドできることを確認


## 参考文献 (Optional)

- なし
