### PR TITLE
[webapp/go] SRIDを削除

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1006,7 +1006,7 @@ func searchEstateNazotte(c echo.Context) error {
 		validatedEstate := EstateSchema{}
 
 		point := fmt.Sprintf("'POINT(%f %f)'", estate.Latitude, estate.Longitude)
-		sqlstr := `SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s, %v))`
+		sqlstr := `SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s))`
 		sqlstr = fmt.Sprintf(sqlstr, coordinates.coordinatesToText(), point)
 
 		err = db.Get(&validatedEstate, sqlstr, estate.ID)

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -18,8 +18,6 @@ import (
 	echopprof "github.com/sevenNt/echo-pprof"
 )
 
-const SRID = 6668
-
 const LIMIT = 20
 const NAZOTTE_LIMIT = 200
 
@@ -1009,7 +1007,7 @@ func searchEstateNazotte(c echo.Context) error {
 
 		point := fmt.Sprintf("'POINT(%f %f)'", estate.Latitude, estate.Longitude)
 		sqlstr := `SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s, %v))`
-		sqlstr = fmt.Sprintf(sqlstr, coordinates.coordinatesToText(), point, SRID)
+		sqlstr = fmt.Sprintf(sqlstr, coordinates.coordinatesToText(), point)
 
 		err = db.Get(&validatedEstate, sqlstr, estate.ID)
 		if err != nil {
@@ -1102,5 +1100,5 @@ func (cs Coordinates) coordinatesToText() string {
 	for _, c := range cs.Coordinates {
 		PolygonArray = append(PolygonArray, fmt.Sprintf("%f %f", c.Latitude, c.Longitude))
 	}
-	return fmt.Sprintf("'POLYGON((%s))', %d", strings.Join(PolygonArray, ","), SRID)
+	return fmt.Sprintf("'POLYGON((%s))'", strings.Join(PolygonArray, ","))
 }


### PR DESCRIPTION
## 目的

- `SPATIAL INDEX` の効かない MySQL では `SRID` は意味を成さない
- 競技者の混乱を少しでも防ぐため、削除しておくことにした


## 解決方法

- `SRID` を指定しない


## 動作確認

- [x] webapp/go が正常に動作することをベンチマーカーを用いて確認


## 参考文献 (Optional)

- なし
