### PR TITLE
[webapp/go] /initializeをPOST methodで行う

### DIFF
--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -26,7 +26,7 @@ type Coordinate struct {
 }
 
 func (c *Client) Initialize(ctx context.Context) error {
-	req, err := c.newGetRequest(ShareTargetURLs.AppURL, "/initialize")
+	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/initialize", nil)
 	if err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker)
 	}
@@ -36,7 +36,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 
 	res, err := c.Do(req)
 	if err != nil {
-		return failure.Wrap(err, failure.Message("GET /initialize: リクエストに失敗しました"))
+		return failure.Wrap(err, failure.Message("POST /initialize: リクエストに失敗しました"))
 	}
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
@@ -44,7 +44,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 	// MEMO: /initializeの成功ステータスによって第二引数が変わる可能性がある
 	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
-		return failure.Wrap(err, failure.Message("GET /initialize: レスポンスコードが不正です"))
+		return failure.Wrap(err, failure.Message("POST /initialize: レスポンスコードが不正です"))
 	}
 
 	return nil

--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -19,7 +19,7 @@ verification_data: ./make_verification_data
 	docker-compose -f ../webapp/docker-compose.yaml down -v
 	docker-compose -f ../webapp/docker-compose.yaml up -d mysql api-server
 	wayt http -u "http://localhost:1323/api/estate/range"
-	curl "localhost:1323/initialize"
+	curl -X POST "localhost:1323/initialize"
 	go build -o ./make_verification_data/main ./make_verification_data/*.go
 	./make_verification_data/main -dest-dir ./result/verification_data -target-url http://localhost:1323
 	docker-compose -f ../webapp/docker-compose.yaml down -v

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -391,7 +391,7 @@ func main() {
 	e.Use(middleware.Recover())
 
 	// Initialize
-	e.GET("/initialize", initialize)
+	e.POST("/initialize", initialize)
 
 	// Chair Handler
 	e.GET("/api/chair/:id", getChairDetail)


### PR DESCRIPTION
## 目的

- `/initialize` はサーバー内のデータに変更をもたらすため、 `POST` のほうが好ましい


## 解決方法

- `GET /initialize` から `POST /initialize` に変更


## 動作確認

- [x] ベンチマーカーが正常に動作することを確認


## 参考文献 (Optional)

- なし
