### PR TITLE
[bench] botのリクエストが503で拒否された場合にErrTemporaryとして扱われてしまっていたのを修正

### DIFF
--- a/bench/client/client.go
+++ b/bench/client/client.go
@@ -142,7 +142,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	if res.StatusCode == http.StatusServiceUnavailable {
+	if  !c.isBot && res.StatusCode == http.StatusServiceUnavailable {
 		return nil, failure.New(fails.ErrTemporary)
 	}
 


### PR DESCRIPTION
## 目的

- bot からのリクエストに対しては `503 Service Unavailable` を返すのが妥当である
- しかし、 `client.Client.Do` 内で `503` が帰ってきた場合に `ErrTemporary` として処理していた


## 解決方法

- bot に対する `503` も `ErrBot` として取り扱う


## 動作確認

- [x] bot に対して `503` を返してもベンチマーカーが `ErrTemporary` を出さないことを確認


## 参考文献 (Optional)

- なし
