### PR TITLE
[webapp/go] goのmodule名をgoからisuumoに変更

### DIFF
--- a/webapp/go/go.mod
+++ b/webapp/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/isucon/isucon10-qualify/webapp/go
+module github.com/isucon/isucon10-qualify/isuumo
 
 go 1.14
 


### PR DESCRIPTION
## 目的

- `webapp/go/go.mod` に記載されていた module 名は `github.com/isucon/isucon10-qualify/webapp/go` だった
- その為、 `go get` によって `$GOPATH/bin` に `go` という名前のバイナリが追加されてしまい、 `go` コマンドの汚染が行われていた


## 解決方法

- `module` 名を `github.com/isucon/isucon10-qualify/isuumo` に変更


## 動作確認

- [x] `go get` で `$GOPATH/bin` 配下に生成されるバイナリファイル名が `isuumo` であることを確認


## 参考文献 (Optional)

- なし
