### PR TITLE
[webapp/go] なぞって検索の結果の物件をview_countで降順に並べるよう修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -986,7 +986,7 @@ func searchEstateNazotte(c echo.Context) error {
 	b := coordinates.getBoundingBox()
 	estatesInBoundingBox := []EstateSchema{}
 
-	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count`
+	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC`
 
 	err = db.Select(&estatesInBoundingBox, sqlstr, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
## 目的

- なぞって検索の結果は、物件の閲覧数によってソートして返すようにしていた
- 本来の想定では人気の物件を表示させたいという考えの元、閲覧数の多い物件を返すようにする予定だった
- しかし、実装では閲覧数の少ない物件を返していた


## 解決方法

- `ORDER BY view_count DESC` にした


## 動作確認

- [x] なぞって検索の結果が閲覧数での降順になっていることを確認


## 参考文献 (Optional)

- なし
