### PR TITLE
[webapp/go] なぞって検索のレスポンスに含む物件数を50件に減らす

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const LIMIT = 20
-const NAZOTTE_LIMIT = 200
+const NAZOTTE_LIMIT = 50
 
 var db *sqlx.DB
 var MySQLConnectionData *MySQLConnectionEnv


### PR DESCRIPTION
## 目的

- なぞって検索のレスポンスボディが大きくなりすぎてしまう為、帯域を食いつぶしていた
- これは、 `description` が長すぎることが原因の一つとして考えられる
- 他にも、返している物件数が 200 件と多いことが原因として考えられる


## 解決方法

- 暫定的対応として、返す物件数を 50 件にまで減らす


## 動作確認

- [x] `POST /api/estate/nazotte` のレスポンスに含まれる物件数が最大 50 件となっていることを確認


## 参考文献 (Optional)

- なし
