### PR TITLE
[webapp/go] なぞって検索の結果の物件数が上限より1多かったのを修正

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -1021,10 +1021,10 @@ func searchEstateNazotte(c echo.Context) error {
 	var re EstateSearchResponse
 	re.Estates = []*Estate{}
 	for i, estate := range estatesInPolygon {
-		re.Estates = append(re.Estates, estate.ToEstate())
 		if i >= NAZOTTE_LIMIT {
 			break
 		}
+		re.Estates = append(re.Estates, estate.ToEstate())
 	}
 	re.Count = int64(len(re.Estates))
 


### PR DESCRIPTION
## 目的

- なぞって検索の結果の `count` が `NAZOTTE_LIMIT + 1` であるようなケースがあった


## 解決方法

- `count` の最大値が `NAZOTTE_LIMIT` になるように修正


## 動作確認

- [x] `count` の最大値が `NAXOTTE_LIMIT` になっていることを確認
	- `grep -H -o -E '\\"count\\": .*?,' /initial-data/result/verification_data/estate_nazotte/*.json`


## 参考文献 (Optional)

- なし
