### PR TITLE
[bench] workerを増やす時間間隔を5秒に変更

### DIFF
--- a/bench/paramater/paramater.go
+++ b/bench/paramater/paramater.go
@@ -19,7 +19,7 @@ const (
 	SleepSwingOnUserAway                  = 100 // * time.Millisecond
 	SleepTimeOnBotInterval                = 500 * time.Millisecond
 	SleepSwingOnBotInterval               = 100 // * time.Millisecond
-	IntervalForCheckWorkers               = 10 * time.Second
+	IntervalForCheckWorkers               = 5 * time.Second
 	ThresholdTimeOfAbandonmentPage        = 1 * time.Second
 	DefaultAPITimeout                     = 2000 * time.Millisecond
 	InitializeTimeout                     = 180 * time.Second


### PR DESCRIPTION
## 目的

- 負荷上昇が 10 秒に 1 回だと、ベンチマークの結果の点数が理論値に到達してしまうことが判明した


## 解決方法

- 負荷上昇のインターバルを 10 秒から 5 秒に変更


## 動作確認

- [x] ベンチマークが正常に動作することを確認


## 参考文献 (Optional)

- なし
