### PR TITLE
[webapp/go] 検索やおすすめの結果で、閲覧数が同数の場合はidでソートする

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -614,7 +614,7 @@ func searchChairs(c echo.Context) error {
 	sqlstr := "SELECT * FROM chair WHERE "
 	searchCondition := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY view_count DESC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM chair WHERE "
 	err = db.Get(&chairs.Count, countsql+searchCondition, queryParams...)
@@ -708,7 +708,7 @@ func responseChairRange(c echo.Context) error {
 func searchRecommendChair(c echo.Context) error {
 	var recommendChairs []ChairSchema
 
-	sqlstr := `SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC LIMIT ?`
+	sqlstr := `SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC, id ASC LIMIT ?`
 
 	err := db.Select(&recommendChairs, sqlstr, LIMIT)
 	if err != nil {
@@ -878,7 +878,7 @@ func searchEstates(c echo.Context) error {
 	sqlstr := "SELECT * FROM estate WHERE "
 	searchQuery := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY view_count DESC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM estate WHERE "
 	err = db.Get(&estates.Count, countsql+searchQuery, searchQueryParameter...)
@@ -908,7 +908,7 @@ func searchEstates(c echo.Context) error {
 func searchRecommendEstate(c echo.Context) error {
 	recommendEstates := make([]EstateSchema, 0, LIMIT)
 
-	sqlstr := `SELECT * FROM estate ORDER BY view_count DESC LIMIT ?`
+	sqlstr := `SELECT * FROM estate ORDER BY view_count DESC, id ASC LIMIT ?`
 
 	err := db.Select(&recommendEstates, sqlstr, LIMIT)
 	if err != nil {
@@ -952,7 +952,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 	w := chair.Width
 	h := chair.Height
 	d := chair.Depth
-	sqlstr = `SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY view_count DESC LIMIT ?`
+	sqlstr = `SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY view_count DESC, id ASC LIMIT ?`
 	err = db.Select(&recommendEstates, sqlstr, w, h, w, d, h, w, h, d, d, w, d, h, LIMIT)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -986,7 +986,7 @@ func searchEstateNazotte(c echo.Context) error {
 	b := coordinates.getBoundingBox()
 	estatesInBoundingBox := []EstateSchema{}
 
-	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC`
+	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC, id ASC`
 
 	err = db.Select(&estatesInBoundingBox, sqlstr, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
## 目的

- 検索やオススメの結果、閲覧数が同数のイスや物件の順序は定まっていなかった
- これにより Verify の Snapshot が落ちているのではないかという意見があった


## 解決方法

- 閲覧数が同数の場合は `id` で昇順にソートするように変更


## 動作確認

- [x] ベンチマーカーが正常に動作することを確認


## 参考文献 (Optional)

- なし
