### PR TITLE
[bench] snapshot形式のVerifyが落ちる理由をlogとして出力する

### DIFF
--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -94,8 +94,7 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreChairUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -134,8 +133,7 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -169,8 +167,7 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreChairUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -204,8 +201,7 @@ func verifyRecommendedEstate(ctx context.Context, c *client.Client, filePath str
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -247,8 +243,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -288,8 +283,7 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			log.Printf("%s\n%s\n", filePath, diff)
+			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -94,7 +95,8 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
@@ -133,7 +135,8 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
@@ -167,7 +170,8 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
@@ -201,7 +205,8 @@ func verifyRecommendedEstate(ctx context.Context, c *client.Client, filePath str
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
@@ -243,7 +248,8 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		}
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
@@ -283,7 +289,8 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
+			log.Printf("%s\n%s\n", filePath, diff)
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:


### PR DESCRIPTION
## 目的

- Snapshot 形式の Verify が落ちた際に、何が悪かったのかを Debug するのが大変だった
- どういう状態でなぜ落ちたのかを得られるようにエラーに情報を埋め込むことにした


## 解決方法

- 落ちた際に使用していた Snapshot のファイルパスをログに出す
- `go-cmp` で Diff を表示してあげる


## 動作確認

- [x] 落ちた理由がログに出力されていることを確認

```
2020/07/30 15:49:05 verifyWithSnapshot.go:292: ../initial-data/result/verification_data/estate_nazotte/51.json
  client.EstatesResponse{
-       Count: 50,
+       Count: 51,
        Estates: []asset.Estate{
                ... // 48 identical elements
                {ID: 1156, Thumbnail: "/images/estate/e482ba8be87bf69f42d1325cd47e5ed91a891aa541156210f"..., Name: "近藤ISUビルディング", Description: "我は急ぎ歸りて、かの状師の服に着換へ、再び\xe8"..., ...},
                {ID: 2009, Thumbnail: "/images/estate/e482ba8be87bf69f42d1325cd47e5ed91a891aa541156210f"..., Name: "高橋ISUビルディング", Description: "人間は人間だ。野獣ではない。天使でもない。\xe4"..., ...},
+               {
+                       ID:          869,
+                       Thumbnail:   "/images/estate/e482ba8be87bf69f42d1325cd47e5ed91a891aa541156210f7b10565e476dcb4.png",
+                       Name:        "小林 ISUビル",
+                       Description: "要するに農民の生活状態が今のままでは何をやつて見たところで無駄なのだ。もつと根本的な\xe3\x81"...,
+                       Address:     "高知県川崎市中原区西関宿31丁目23番8号 神明内ハイツ282",
+                       Latitude:    36.81499849251271,
+                       Longitude:   137.4032350002722,
+                       DoorHeight:  146,
+                       DoorWidth:   91,
+                       Rent:        171435,
+                       Features:    "オートロック,駐車場あり,インターネット無料,ペット飼育可能",
+               },
        },
  }

2020/07/30 15:49:05 fails.go:102: [scenario.verifyEstateNazotte] isucon10-qualify/bench/scenario/verifyWithSnapshot.go:293
    message("POST /api/estate/nazotte: 物件の検索結果が不正です")
    message("snapshot: ../initial-data/result/verification_data/estate_nazotte/51.json")
    code(error application)
[CallStack]
    [scenario.verifyEstateNazotte] isucon10-qualify/bench/scenario/verifyWithSnapshot.go:293
    [scenario.verifyWithSnapshot.func6] isucon10-qualify/bench/scenario/verifyWithSnapshot.go:413
    [runtime.goexit] /usr/local/Cellar/go/1.14.5/libexec/src/runtime/asm_amd64.s:1373
2020/07/30 15:49:05 bench.go:91: verify failed
{"pass":false,"score":0,"cv":0,"messages":["GET /api/chair/search: イスの検索結果が不正です","GET /api/recommended_chair: イスのおすすめ結果が不正です","GET /api/recommended_estate: 物件のおすすめ結果が不正です","GET /api/recommended_estate:id: 物件のおすすめ結果が不正です","POST /api/estate/nazotte: 物件の検索結果が不正です"]}
```


## 参考文献 (Optional)

- https://github.com/google/go-cmp
