### PR TITLE
[initial-data] Snapshot形式のVerify用データ生成時のSeedを固定する

### DIFF
--- a/initial-data/make_verification_data/main.go
+++ b/initial-data/make_verification_data/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 )
 
 const (
@@ -21,7 +20,7 @@ const (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(19700101)
 }
 
 func writeSnapshotDataToFile(path string, snapshot Snapshot) {


### PR DESCRIPTION
## 目的

- Snapshot 形式の Verify 用データは生成するたびに別のリクエストデータ生成されてしまう
- デバッグの際に不便であることがわかった


## 解決方法

- Seed 値を固定した


## 動作確認

- [x] Snapshot 形式の Verify 用データが生成できることを確認


## 参考文献 (Optional)

- なし
