### PR TITLE
[frontend] 検索結果のCardのスタイルが崩れていたのを修正

### DIFF
--- a/webapp/frontend/src/pages/chair/search/index.tsx
+++ b/webapp/frontend/src/pages/chair/search/index.tsx
@@ -54,6 +54,7 @@ const useChairSearchStyles = makeStyles(theme =>
       marginBottom: theme.spacing(2)
     },
     cardActionArea: {
+      height: 270,
       display: 'flex',
       alignItems: 'flex-start',
       justifyContent: 'flex-start'
@@ -63,6 +64,7 @@ const useChairSearchStyles = makeStyles(theme =>
       height: 270
     },
     cardContent: {
+      width: 'fit-content',
       marginLeft: theme.spacing(1)
     }
   })

--- a/webapp/frontend/src/pages/chair/search/index.tsx
+++ b/webapp/frontend/src/pages/chair/search/index.tsx
@@ -252,8 +252,8 @@ const ChairSearch: FC<ChairSearchProps> = ({ chairRangeMap }) => {
                             <CardMedia image={chair.thumbnail} className={classes.cardMedia} />
                             <CardContent className={classes.cardContent}>
                               <h2>{chair.name}</h2>
-                              <p>価格: {chair.price}円</p>
-                              <p>詳細: {chair.description}</p>
+                              <p><strong>価格:</strong> {chair.price}円</p>
+                              <p><strong>詳細:</strong> {chair.description}</p>
                             </CardContent>
                           </CardActionArea>
                         </Card>

--- a/webapp/frontend/src/pages/estate/search/index.tsx
+++ b/webapp/frontend/src/pages/estate/search/index.tsx
@@ -113,9 +113,9 @@ const EstateItem: FC<EstateItemProps> = ({ estate }) => {
           <CardMedia image={estate.thumbnail} className={classes.cardMedia} />
           <CardContent className={classes.cardContent}>
             <h2>{estate.name}</h2>
-            <p>住所: {estate.address}</p>
-            <p>価格: {estate.rent}円</p>
-            <p>詳細: {estate.description}</p>
+            <p><strong>住所:</strong> {estate.address}</p>
+            <p><strong>価格:</strong> {estate.rent}円</p>
+            <p><strong>詳細:</strong> {estate.description}</p>
           </CardContent>
         </CardActionArea>
       </Card>

--- a/webapp/frontend/src/pages/estate/search/index.tsx
+++ b/webapp/frontend/src/pages/estate/search/index.tsx
@@ -39,6 +39,7 @@ const useEstateItemStyles = makeStyles(theme =>
       marginBottom: theme.spacing(2)
     },
     cardActionArea: {
+      height: 270,
       display: 'flex',
       alignItems: 'flex-start',
       justifyContent: 'flex-start'
@@ -48,6 +49,7 @@ const useEstateItemStyles = makeStyles(theme =>
       height: 270
     },
     cardContent: {
+      width: 'fit-content',
       marginLeft: theme.spacing(1)
     }
   })


### PR DESCRIPTION
## 目的

- 検索結果のCardのスタイルが崩れていた

![image](https://user-images.githubusercontent.com/19568747/88149954-b9c42e00-cc3b-11ea-8ea8-106544b8a330.png)


## 解決方法

- スタイルを修正


## 動作確認

- [x] スタイルが修正されていることを確認

![image](https://user-images.githubusercontent.com/19568747/88149865-9c8f5f80-cc3b-11ea-8ece-c6dc5c406142.png)


## 参考文献 (Optional)

- なし
