### PR TITLE
[webapp/go] DBからのデータを受け取るための型を削除

### DIFF
--- a/bench/go.mod
+++ b/bench/go.mod
@@ -3,6 +3,7 @@ module github.com/isucon10-qualify/isucon10-qualify/bench
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.1
 	github.com/morikuni/failure v0.12.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -1,6 +1,10 @@
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/morikuni/failure v0.12.1 h1:J/Bk9y8834TDUCbETEBUfDGtq3ewk8muGVL/PddrD/M=
 github.com/morikuni/failure v0.12.1/go.mod h1:+IjvKCz9B/D4BQrTzYLwERdWyMkGJdu+q5gri9dWecg=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -9,11 +9,13 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/morikuni/failure"
@@ -26,6 +28,11 @@ const (
 	NumOfVerifyRecommendedEstate          = 1
 	NumOfVerifyRecommendedEstateWithChair = 3
 	NumOfVerifyEstateNazotte              = 3
+)
+
+var (
+	ignoreChairUnexported  = cmpopts.IgnoreUnexported(asset.Chair{})
+	ignoreEstateUnexported = cmpopts.IgnoreUnexported(asset.Estate{})
 )
 
 type Request struct {
@@ -85,8 +92,9 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:
@@ -123,8 +131,9 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:
@@ -156,8 +165,9 @@ func verifyRecommendedChair(ctx context.Context, c *client.Client, filePath stri
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_chair: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreChairUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_chair: イスのおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:
@@ -189,8 +199,9 @@ func verifyRecommendedEstate(ctx context.Context, c *client.Client, filePath str
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:
@@ -230,8 +241,9 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		if err != nil {
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate:id: Response BodyのUnmarshalでエラーが発生しました"))
 		}
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate:id: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:
@@ -269,8 +281,9 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: Response BodyのUnmarshalでエラーが発生しました"))
 		}
 
-		if !reflect.DeepEqual(expected, actual) {
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			diff := cmp.Diff(*expected, *actual, ignoreEstateUnexported)
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath), failure.Message(diff))
 		}
 
 	default:

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -210,14 +210,13 @@ type Chair struct {
 }
 
 type ChairSearchResponse struct {
-	Count  int64    `json:"count"`
+	Count  int64   `json:"count"`
 	Chairs []Chair `json:"chairs"`
 }
 
 type ChairRecommendResponse struct {
 	Chairs []Chair `json:"chairs"`
 }
-
 
 //Estate 物件
 type Estate struct {
@@ -237,7 +236,7 @@ type Estate struct {
 
 //EstateSearchResponse estate/searchへのレスポンスの形式
 type EstateSearchResponse struct {
-	Count   int64     `json:"count"`
+	Count   int64    `json:"count"`
 	Estates []Estate `json:"estates"`
 }
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -211,11 +211,11 @@ type Chair struct {
 
 type ChairSearchResponse struct {
 	Count  int64    `json:"count"`
-	Chairs []*Chair `json:"chairs"`
+	Chairs []Chair `json:"chairs"`
 }
 
 type ChairRecommendResponse struct {
-	Chairs []*Chair `json:"chairs"`
+	Chairs []Chair `json:"chairs"`
 }
 
 
@@ -238,11 +238,11 @@ type Estate struct {
 //EstateSearchResponse estate/searchへのレスポンスの形式
 type EstateSearchResponse struct {
 	Count   int64     `json:"count"`
-	Estates []*Estate `json:"estates"`
+	Estates []Estate `json:"estates"`
 }
 
 type EstateRecommendResponse struct {
-	Estates []*Estate `json:"estates"`
+	Estates []Estate `json:"estates"`
 }
 
 type Coordinate struct {
@@ -550,7 +550,7 @@ func searchChairs(c echo.Context) error {
 	}
 
 	var chairs ChairSearchResponse
-	chairs.Chairs = []*Chair{}
+	chairs.Chairs = []Chair{}
 	sqlstr := "SELECT * FROM chair WHERE "
 	searchCondition := strings.Join(searchQueryArray, " AND ")
 
@@ -568,14 +568,14 @@ func searchChairs(c echo.Context) error {
 	err = db.Select(&searchedchairs, sqlstr+searchCondition+limitOffset, queryParams...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusOK, ChairSearchResponse{Count: 0, Chairs: []*Chair{}})
+			return c.JSON(http.StatusOK, ChairSearchResponse{Count: 0, Chairs: []Chair{}})
 		}
 		c.Logger().Errorf("searchChairs DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	for _, c := range searchedchairs {
-		chairs.Chairs = append(chairs.Chairs, &c)
+		chairs.Chairs = append(chairs.Chairs, c)
 	}
 
 	return c.JSON(http.StatusOK, chairs)
@@ -654,7 +654,7 @@ func searchRecommendChair(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.Logger().Error("searchRecommendChair not found")
-			return c.JSON(http.StatusOK, ChairRecommendResponse{[]*Chair{}})
+			return c.JSON(http.StatusOK, ChairRecommendResponse{[]Chair{}})
 		}
 		c.Logger().Errorf("searchRecommendChair DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -663,7 +663,7 @@ func searchRecommendChair(c echo.Context) error {
 	var rc ChairRecommendResponse
 
 	for _, chair := range recommendChairs {
-		rc.Chairs = append(rc.Chairs, &chair)
+		rc.Chairs = append(rc.Chairs, chair)
 	}
 
 	return c.JSON(http.StatusOK, rc)
@@ -814,7 +814,7 @@ func searchEstates(c echo.Context) error {
 	}
 
 	var estates EstateSearchResponse
-	estates.Estates = []*Estate{}
+	estates.Estates = []Estate{}
 	sqlstr := "SELECT * FROM estate WHERE "
 	searchQuery := strings.Join(searchQueryArray, " AND ")
 
@@ -832,14 +832,14 @@ func searchEstates(c echo.Context) error {
 	err = db.Select(&matchestates, sqlstr+searchQuery+limitOffset, searchQueryParameter...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+			return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []Estate{}})
 		}
 		c.Logger().Errorf("searchEstates DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	for _, e := range matchestates {
-		estates.Estates = append(estates.Estates, &e)
+		estates.Estates = append(estates.Estates, e)
 	}
 
 	return c.JSON(http.StatusOK, estates)
@@ -854,7 +854,7 @@ func searchRecommendEstate(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.Logger().Error("searchRecommendEstate not found")
-			return c.JSON(http.StatusOK, EstateRecommendResponse{[]*Estate{}})
+			return c.JSON(http.StatusOK, EstateRecommendResponse{[]Estate{}})
 		}
 		c.Logger().Errorf("searchRecommendEstate DB execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -862,7 +862,7 @@ func searchRecommendEstate(c echo.Context) error {
 	var re EstateRecommendResponse
 
 	for _, estate := range recommendEstates {
-		re.Estates = append(re.Estates, &estate)
+		re.Estates = append(re.Estates, estate)
 	}
 
 	return c.JSON(http.StatusOK, re)
@@ -896,7 +896,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 	err = db.Select(&recommendEstates, sqlstr, w, h, w, d, h, w, h, d, d, w, d, h, LIMIT)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return c.JSON(http.StatusOK, EstateRecommendResponse{[]*Estate{}})
+			return c.JSON(http.StatusOK, EstateRecommendResponse{[]Estate{}})
 		}
 		c.Logger().Errorf("Database execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -905,7 +905,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 	var re EstateRecommendResponse
 
 	for _, estate := range recommendEstates {
-		re.Estates = append(re.Estates, &estate)
+		re.Estates = append(re.Estates, estate)
 	}
 
 	return c.JSON(http.StatusOK, re)
@@ -931,7 +931,7 @@ func searchEstateNazotte(c echo.Context) error {
 	err = db.Select(&estatesInBoundingBox, sqlstr, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {
 		c.Echo().Logger.Infof("select * from estate where latitude ...", err)
-		return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []*Estate{}})
+		return c.JSON(http.StatusOK, EstateSearchResponse{Count: 0, Estates: []Estate{}})
 	} else if err != nil {
 		c.Echo().Logger.Errorf("database execution error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
@@ -959,12 +959,12 @@ func searchEstateNazotte(c echo.Context) error {
 	}
 
 	var re EstateSearchResponse
-	re.Estates = []*Estate{}
+	re.Estates = []Estate{}
 	for i, estate := range estatesInPolygon {
 		if i >= NAZOTTE_LIMIT {
 			break
 		}
-		re.Estates = append(re.Estates, &estate)
+		re.Estates = append(re.Estates, estate)
 	}
 	re.Count = int64(len(re.Estates))
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -193,34 +193,20 @@ var ChairDepthRanges = []*Range{
 	},
 }
 
-type ChairSchema struct {
-	ID          int64  `db:"id"`
-	Thumbnail   string `db:"thumbnail"`
-	Name        string `db:"name"`
-	Description string `db:"description"`
-	Price       int64  `db:"price"`
-	Height      int64  `db:"height"`
-	Width       int64  `db:"width"`
-	Depth       int64  `db:"depth"`
-	ViewCount   int64  `db:"view_count"`
-	Stock       int64  `db:"stock"`
-	Color       string `db:"color"`
-	Features    string `db:"features"`
-	Kind        string `db:"kind"`
-}
-
 type Chair struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Thumbnail   string `json:"thumbnail"`
-	Price       int64  `json:"price"`
-	Height      int64  `json:"height"`
-	Width       int64  `json:"width"`
-	Depth       int64  `json:"depth"`
-	Color       string `json:"color"`
-	Features    string `json:"features"`
-	Kind        string `json:"kind"`
+	ID          int64  `db:"id" json:"id"`
+	Name        string `db:"name" json:"name"`
+	Description string `db:"description" json:"description"`
+	Thumbnail   string `db:"thumbnail" json:"thumbnail"`
+	Price       int64  `db:"price" json:"price"`
+	Height      int64  `db:"height" json:"height"`
+	Width       int64  `db:"width" json:"width"`
+	Depth       int64  `db:"depth" json:"depth"`
+	Color       string `db:"color" json:"color"`
+	Features    string `db:"features" json:"features"`
+	Kind        string `db:"kind" json:"kind"`
+	ViewCount   int64  `db:"view_count" json:"-"`
+	Stock       int64  `db:"stock" json:"-"`
 }
 
 type ChairSearchResponse struct {
@@ -232,52 +218,21 @@ type ChairRecommendResponse struct {
 	Chairs []*Chair `json:"chairs"`
 }
 
-func (cs *ChairSchema) ToChair() *Chair {
-	return &Chair{
-		ID:          cs.ID,
-		Name:        cs.Name,
-		Description: cs.Description,
-		Thumbnail:   cs.Thumbnail,
-		Price:       cs.Price,
-		Height:      cs.Height,
-		Width:       cs.Width,
-		Depth:       cs.Depth,
-		Color:       cs.Color,
-		Features:    cs.Features,
-		Kind:        cs.Kind,
-	}
-}
 
-//EstateSchema estate tableに格納されている物件データ
-type EstateSchema struct {
-	ID          int64   `db:"id"`
-	Thumbnail   string  `db:"thumbnail"`
-	Name        string  `db:"name"`
-	Description string  `db:"description"`
-	Latitude    float64 `db:"latitude"`
-	Longitude   float64 `db:"longitude"`
-	Address     string  `db:"address"`
-	Rent        int64   `db:"rent"`
-	DoorHeight  int64   `db:"door_height"`
-	DoorWidth   int64   `db:"door_width"`
-	ViewCount   int64   `db:"view_count"`
-	Features    string  `db:"features"`
-}
-
-func (es *EstateSchema) ToEstate() *Estate {
-	return &Estate{
-		ID:          es.ID,
-		Thumbnail:   es.Thumbnail,
-		Name:        es.Name,
-		Description: es.Description,
-		Address:     es.Address,
-		Latitude:    es.Latitude,
-		Longitude:   es.Longitude,
-		DoorHeight:  es.DoorHeight,
-		DoorWidth:   es.DoorWidth,
-		Rent:        es.Rent,
-		Features:    es.Features,
-	}
+//Estate 物件
+type Estate struct {
+	ID          int64   `db:"id" json:"id"`
+	Thumbnail   string  `db:"thumbnail" json:"thumbnail"`
+	Name        string  `db:"name" json:"name"`
+	Description string  `db:"description" json:"description"`
+	Latitude    float64 `db:"latitude" json:"latitude"`
+	Longitude   float64 `db:"longitude" json:"longitude"`
+	Address     string  `db:"address" json:"address"`
+	Rent        int64   `db:"rent" json:"rent"`
+	DoorHeight  int64   `db:"door_height" json:"doorHeight"`
+	DoorWidth   int64   `db:"door_width" json:"doorWidth"`
+	Features    string  `db:"features" json:"features"`
+	ViewCount   int64   `db:"view_count" json:"-"`
 }
 
 //EstateSearchResponse estate/searchへのレスポンスの形式
@@ -288,21 +243,6 @@ type EstateSearchResponse struct {
 
 type EstateRecommendResponse struct {
 	Estates []*Estate `json:"estates"`
-}
-
-//Estate 物件
-type Estate struct {
-	ID          int64   `json:"id"`
-	Thumbnail   string  `json:"thumbnail"`
-	Name        string  `json:"name"`
-	Description string  `json:"description"`
-	Address     string  `json:"address"`
-	Latitude    float64 `json:"latitude"`
-	Longitude   float64 `json:"longitude"`
-	DoorHeight  int64   `json:"doorHeight"`
-	DoorWidth   int64   `json:"doorWidth"`
-	Rent        int64   `json:"rent"`
-	Features    string  `json:"features"`
 }
 
 type Coordinate struct {
@@ -456,7 +396,7 @@ func getChairDetail(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	chair := ChairSchema{}
+	chair := Chair{}
 	sqlstr := "SELECT * FROM chair WHERE id = ?"
 	err = db.Get(&chair, sqlstr, id)
 	if err != nil {
@@ -490,7 +430,7 @@ func getChairDetail(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	return c.JSON(http.StatusOK, chair.ToChair())
+	return c.JSON(http.StatusOK, chair)
 }
 
 func searchChairs(c echo.Context) error {
@@ -623,7 +563,7 @@ func searchChairs(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	searchedchairs := []ChairSchema{}
+	searchedchairs := []Chair{}
 	queryParams = append(queryParams, perpage, page*perpage)
 	err = db.Select(&searchedchairs, sqlstr+searchCondition+limitOffset, queryParams...)
 	if err != nil {
@@ -635,7 +575,7 @@ func searchChairs(c echo.Context) error {
 	}
 
 	for _, c := range searchedchairs {
-		chairs.Chairs = append(chairs.Chairs, c.ToChair())
+		chairs.Chairs = append(chairs.Chairs, &c)
 	}
 
 	return c.JSON(http.StatusOK, chairs)
@@ -648,7 +588,7 @@ func buyChair(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	var chair ChairSchema
+	var chair Chair
 	err = db.Get(&chair, "SELECT * FROM chair WHERE id = ? AND stock > 0", id)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -706,7 +646,7 @@ func responseChairRange(c echo.Context) error {
 }
 
 func searchRecommendChair(c echo.Context) error {
-	var recommendChairs []ChairSchema
+	var recommendChairs []Chair
 
 	sqlstr := `SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC LIMIT ?`
 
@@ -723,7 +663,7 @@ func searchRecommendChair(c echo.Context) error {
 	var rc ChairRecommendResponse
 
 	for _, chair := range recommendChairs {
-		rc.Chairs = append(rc.Chairs, chair.ToChair())
+		rc.Chairs = append(rc.Chairs, &chair)
 	}
 
 	return c.JSON(http.StatusOK, rc)
@@ -736,7 +676,7 @@ func getEstateDetail(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	var estate EstateSchema
+	var estate Estate
 	err = db.Get(&estate, "SELECT * FROM estate WHERE id = ?", id)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -764,7 +704,7 @@ func getEstateDetail(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	return c.JSON(http.StatusOK, estate.ToEstate())
+	return c.JSON(http.StatusOK, estate)
 }
 
 func getRange(RangeID string, Ranges []*Range) (*Range, error) {
@@ -887,7 +827,7 @@ func searchEstates(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	matchestates := []EstateSchema{}
+	matchestates := []Estate{}
 	searchQueryParameter = append(searchQueryParameter, perpage, page*perpage)
 	err = db.Select(&matchestates, sqlstr+searchQuery+limitOffset, searchQueryParameter...)
 	if err != nil {
@@ -899,14 +839,14 @@ func searchEstates(c echo.Context) error {
 	}
 
 	for _, e := range matchestates {
-		estates.Estates = append(estates.Estates, e.ToEstate())
+		estates.Estates = append(estates.Estates, &e)
 	}
 
 	return c.JSON(http.StatusOK, estates)
 }
 
 func searchRecommendEstate(c echo.Context) error {
-	recommendEstates := make([]EstateSchema, 0, LIMIT)
+	recommendEstates := make([]Estate, 0, LIMIT)
 
 	sqlstr := `SELECT * FROM estate ORDER BY view_count DESC LIMIT ?`
 
@@ -922,7 +862,7 @@ func searchRecommendEstate(c echo.Context) error {
 	var re EstateRecommendResponse
 
 	for _, estate := range recommendEstates {
-		re.Estates = append(re.Estates, estate.ToEstate())
+		re.Estates = append(re.Estates, &estate)
 	}
 
 	return c.JSON(http.StatusOK, re)
@@ -935,7 +875,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	chair := ChairSchema{}
+	chair := Chair{}
 	sqlstr := `SELECT * FROM chair WHERE id = ?`
 
 	err = db.Get(&chair, sqlstr, id)
@@ -948,7 +888,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	var recommendEstates []EstateSchema
+	var recommendEstates []Estate
 	w := chair.Width
 	h := chair.Height
 	d := chair.Depth
@@ -965,7 +905,7 @@ func searchRecommendEstateWithChair(c echo.Context) error {
 	var re EstateRecommendResponse
 
 	for _, estate := range recommendEstates {
-		re.Estates = append(re.Estates, estate.ToEstate())
+		re.Estates = append(re.Estates, &estate)
 	}
 
 	return c.JSON(http.StatusOK, re)
@@ -984,7 +924,7 @@ func searchEstateNazotte(c echo.Context) error {
 	}
 
 	b := coordinates.getBoundingBox()
-	estatesInBoundingBox := []EstateSchema{}
+	estatesInBoundingBox := []Estate{}
 
 	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC`
 
@@ -997,9 +937,9 @@ func searchEstateNazotte(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	estatesInPolygon := []EstateSchema{}
+	estatesInPolygon := []Estate{}
 	for _, estate := range estatesInBoundingBox {
-		validatedEstate := EstateSchema{}
+		validatedEstate := Estate{}
 
 		point := fmt.Sprintf("'POINT(%f %f)'", estate.Latitude, estate.Longitude)
 		sqlstr := `SELECT * FROM estate WHERE id = ? AND ST_Contains(ST_PolygonFromText(%s), ST_GeomFromText(%s))`
@@ -1024,7 +964,7 @@ func searchEstateNazotte(c echo.Context) error {
 		if i >= NAZOTTE_LIMIT {
 			break
 		}
-		re.Estates = append(re.Estates, estate.ToEstate())
+		re.Estates = append(re.Estates, &estate)
 	}
 	re.Count = int64(len(re.Estates))
 


### PR DESCRIPTION
## 目的

- `ChairSchema` と `EstateSchema` が冗長で、省略できると判断した


## 解決方法

- `ChairSchema` と `EstateSchema` を `Chair` と `Estate` にまとめた


## 動作確認

- [x] ベンチマーカーが正常に終了することを確認


## 参考文献 (Optional)

- https://golang.org/pkg/encoding/json/#Marshal
