### PR TITLE
[webapp/mysql] MySQL特有の記述を減らす

### DIFF
--- a/initial-data/Makefile
+++ b/initial-data/Makefile
@@ -8,11 +8,11 @@ refresh_estate_data:
 
 chair_data: make_chair_data.py
 	python3 make_chair_data.py
-	cp result/2_DummyChairData.sql ../webapp/mysql/db/2_DummyChairData.sql
+	cp result/chairData.csv ../webapp/mysql/files/chairData.csv
 
 estate_data: make_estate_data.py
 	python3 make_estate_data.py
-	cp result/1_DummyEstateData.sql ../webapp/mysql/db/1_DummyEstateData.sql
+	cp result/estateData.csv ../webapp/mysql/files/estateData.csv
 
 verification_data: ./make_verification_data
 	rm -rf ./result/verification_data

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -11,18 +11,16 @@ Faker.seed(19700101)
 random.seed(19700101)
 
 DESCRIPTION_LINES_FILE = "./description.txt"
-OUTPUT_SQL_FILE = "./result/2_DummyChairData.sql"
+OUTPUT_CSV_FILE = "./result/chairData.csv"
 OUTPUT_TXT_FILE = "./result/chair_json.txt"
 CHAIR_IMAGE_ORIGIN_DIR = "./origin/chair"
 CHAIR_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/chair"
 CHAIR_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
-BULK_INSERT_COUNT = 500
 CHAIR_MIN_CENTIMETER = 30
 CHAIR_MAX_CENTIMETER = 200
 MIN_VIEW_COUNT = 3000
 MAX_VIEW_COUNT = 1000000
-sqlCommands = "use isuumo;\n"
 
 CHAIR_COLOR_LIST = [
     "黒",
@@ -110,6 +108,11 @@ def read_src_file_data(file_path):
         return img.read()
 
 
+def dump_chair_to_csv_str(chair):
+    # id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind
+    return f"{chair['id']},\"{chair['thumbnail']}\",\"{chair['name']}\",{chair['price']},{chair['height']},{chair['width']},{chair['depth']},{chair['view_count']},{chair['stock']},\"{chair['color']}\",\"{chair['description']}\",\"{chair['features']}\",\"{chair['kind']}\""
+
+
 def dump_chair_to_json_str(chair):
     return json.dumps({
         "id": chair["id"],
@@ -166,14 +169,7 @@ if __name__ == "__main__":
     with open(DESCRIPTION_LINES_FILE, mode='r', encoding='utf-8') as description_lines:
         desc_lines = description_lines.readlines()
 
-    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
-        sqlfile.write(sqlCommands)
-        if RECORD_COUNT % BULK_INSERT_COUNT != 0:
-            raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
-                RECORD_COUNT, BULK_INSERT_COUNT))
-
-        chair_id = 1
-
+    with open(OUTPUT_CSV_FILE, mode='w', encoding='utf-8') as csvfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
         CHAIRS_FOR_VERIFY = [
             # 購入された際に在庫が減ることを検証するためのデータ
             generate_chair_dummy_data(1, {
@@ -193,19 +189,12 @@ if __name__ == "__main__":
             })
         ]
 
-        sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
-        sqlfile.write(sqlCommand)
-        txtfile.write(
-            "\n".join([dump_chair_to_json_str(chair) for chair in CHAIRS_FOR_VERIFY]) + "\n")
+        chairs = CHAIRS_FOR_VERIFY + \
+            [generate_chair_dummy_data(len(CHAIRS_FOR_VERIFY) + i + 1)
+             for i in range(RECORD_COUNT)]
 
-        chair_id += len(CHAIRS_FOR_VERIFY)
+        csvfile.write(
+            "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
 
-        for _ in range(RECORD_COUNT // BULK_INSERT_COUNT):
-            bulk_list = [generate_chair_dummy_data(
-                chair_id + i) for i in range(BULK_INSERT_COUNT)]
-            chair_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
-            sqlfile.write(sqlCommand)
-
-            txtfile.write(
-                "\n".join([dump_chair_to_json_str(chair) for chair in bulk_list]) + "\n")
+        txtfile.write("\n".join([dump_chair_to_json_str(chair)
+                                 for chair in chairs]) + "\n")

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -15,6 +15,7 @@ OUTPUT_CSV_FILE = "./result/chairData.csv"
 OUTPUT_TXT_FILE = "./result/chair_json.txt"
 CHAIR_IMAGE_ORIGIN_DIR = "./origin/chair"
 CHAIR_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/chair"
+CSV_COLUMNS_ORDER = "id,thumbnail,name,price,height,width,depth,view_count,stock,color,description,features,kind\n"
 CHAIR_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
 CHAIR_MIN_CENTIMETER = 30
@@ -194,7 +195,7 @@ if __name__ == "__main__":
              for i in range(RECORD_COUNT)]
 
         csvfile.write(
-            "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
+            CSV_COLUMNS_ORDER + "\n".join([dump_chair_to_csv_str(chair) for chair in chairs]))
 
         txtfile.write("\n".join([dump_chair_to_json_str(chair)
                                  for chair in chairs]) + "\n")

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -15,6 +15,7 @@ OUTPUT_CSV_FILE = "./result/estateData.csv"
 OUTPUT_TXT_FILE = "./result/estate_json.txt"
 ESTATE_IMAGE_ORIGIN_DIR = "./origin/estate"
 ESTATE_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/estate"
+CSV_COLUMNS_ORDER = "id,thumbnail,name,latitude,longitude,address,rent,door_height,door_width,view_count,description,features\n"
 ESTATE_DUMMY_IMAGE_NUM = 1000
 RECORD_COUNT = 10 ** 4
 DOOR_MIN_CENTIMETER = 30
@@ -122,7 +123,7 @@ if __name__ == '__main__':
              for i in range(RECORD_COUNT)]
 
         csvfile.write(
-            "\n".join([dump_estate_to_csv_str(estate) for estate in estates]))
+            CSV_COLUMNS_ORDER + "\n".join([dump_estate_to_csv_str(estate) for estate in estates]))
 
         txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                  for estate in estates]) + "\n")

--- a/webapp/docker-compose.yaml
+++ b/webapp/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ./mysql/data:/var/lib/mysql
       - ./mysql/db:/docker-entrypoint-initdb.d
+      - ./mysql/files:/var/lib/mysql-files
       - ./logs/mysql:/var/log/mysql
       - ../provisioning/ansible/roles/web/files/my.cnf:/etc/mysql/conf.d/my.cnf
       - ../provisioning/ansible/roles/web/files/slow-mysqld.cnf:/etc/mysql/conf.d/slowquery.cnf

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -433,8 +433,8 @@ func initialize(c echo.Context) error {
 	fpathprefix := filepath.Join("..", "mysql", "db")
 	paths := []string{
 		filepath.Join(fpathprefix, "0_Schema.sql"),
-		filepath.Join(fpathprefix, "1_DummyEstateData.sql"),
-		filepath.Join(fpathprefix, "2_DummyChairData.sql"),
+		// filepath.Join(fpathprefix, "1_DummyEstateData.sql"),
+		// filepath.Join(fpathprefix, "2_DummyChairData.sql"),
 	}
 
 	for _, p := range paths {

--- a/webapp/mysql/.gitignore
+++ b/webapp/mysql/.gitignore
@@ -1,3 +1,5 @@
 db/1_DummyEstateData.sql
 db/2_DummyChairData.sql
 data
+files/*
+!files/.gitkeep

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -37,5 +37,5 @@ CREATE TABLE chair (
     `kind` VARCHAR(64) NOT NULL
 )ENGINE=InnoDB;
 
-LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
-LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -1,41 +1,39 @@
 DROP DATABASE IF EXISTS isuumo;
-CREATE DATABASE isuumo DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE isuumo;
 
-USE isuumo;
+DROP TABLE IF EXISTS isuumo.estate;
+DROP TABLE IF EXISTS isuumo.chair;
 
-DROP TABLE IF EXISTS estate;
-DROP TABLE IF EXISTS chair;
+CREATE TABLE isuumo.estate (
+    id INTEGER PRIMARY KEY,
+    thumbnail VARCHAR(256) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    address VARCHAR(128) NOT NULL,
+    rent INTEGER NOT NULL,
+    door_height INTEGER NOT NULL,
+    door_width INTEGER NOT NULL,
+    view_count INTEGER DEFAULT 0 NOT NULL,
+    description TEXT NOT NULL,
+    features VARCHAR(256) NOT NULL
+);
 
-CREATE TABLE estate (
-    `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
-    `thumbnail` VARCHAR(256) NOT NULL,
-    `name` VARCHAR(64) NOT NULL,
-    `latitude` DOUBLE NOT NULL,
-    `longitude` DOUBLE NOT NULL,
-    `address` VARCHAR(128) NOT NULL,
-    `rent` INTEGER NOT NULL,
-    `door_height` INTEGER NOT NULL,
-    `door_width` INTEGER NOT NULL,
-    `view_count` INTEGER DEFAULT 0 NOT NULL,
-    `description` TEXT NOT NULL,
-    `features` VARCHAR(256) NOT NULL
-)ENGINE=InnoDB;
+CREATE TABLE isuumo.chair (
+    id INTEGER PRIMARY KEY,
+    thumbnail TEXT,
+    name VARCHAR(64) NOT NULL,
+    description TEXT NOT NULL,
+    price INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    width INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    view_count INTEGER NOT NULL DEFAULT 0,
+    stock INTEGER NOT NULL DEFAULT 0,
+    color VARCHAR(64) NOT NULL,
+    features VARCHAR(64) NOT NULL,
+    kind VARCHAR(64) NOT NULL
+);
 
-CREATE TABLE chair (
-    `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
-    `thumbnail` TEXT,
-    `name` VARCHAR(64) NOT NULL,
-    `description` TEXT NOT NULL,
-    `price` INTEGER NOT NULL,
-    `height` INTEGER NOT NULL,
-    `width` INTEGER NOT NULL,
-    `depth` INTEGER NOT NULL,
-    `view_count` INTEGER NOT NULL DEFAULT 0,
-    `stock` INTEGER NOT NULL DEFAULT 0,
-    `color` VARCHAR(64) NOT NULL,
-    `features` VARCHAR(64) NOT NULL,
-    `kind` VARCHAR(64) NOT NULL
-)ENGINE=InnoDB;
-
-LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
-LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE isuumo.chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE isuumo.estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 LINES (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -36,3 +36,6 @@ CREATE TABLE chair (
     `features` VARCHAR(64) NOT NULL,
     `kind` VARCHAR(64) NOT NULL
 )ENGINE=InnoDB;
+
+LOAD DATA INFILE '/var/lib/mysql-files/chairData.csv' INTO TABLE chair FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind);
+LOAD DATA INFILE '/var/lib/mysql-files/estateData.csv' INTO TABLE estate FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features);


### PR DESCRIPTION
## 目的

- PostGIS を使用していることから MySQL から PostgreSQL への移行を考える競技者が現れる可能性がある
- 現状の SQL ファイルは MySQL Specific な記述が多く、 PostgreSQL で動かすためには多くの修正が必要になる
- ただでさえ PostgreSQL への移行に時間がかかることから、このような手間は最小限に抑えておく


## 解決方法

- MySQL Specific な記述を避け、 SQL の仕様に寄せる


## 動作確認

- [x] `GET /initialize` により DB の初期化が完了することを確認


## 参考文献 (Optional)

- なし
