### PR TITLE
[webapp] /initializeの際に、使用言語を返してもらう

### DIFF
--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -25,10 +25,14 @@ type Coordinate struct {
 	Longitude float64 `json:"longitude"`
 }
 
-func (c *Client) Initialize(ctx context.Context) error {
+type InitializeResponse struct {
+	Language string `json:"language"`
+}
+
+func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/initialize", nil)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker)
+		return nil, failure.Translate(err, fails.ErrBenchmarker)
 	}
 
 	// T/O付きのコンテキストが入る
@@ -36,7 +40,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 
 	res, err := c.Do(req)
 	if err != nil {
-		return failure.Wrap(err, failure.Message("POST /initialize: リクエストに失敗しました"))
+		return nil, failure.Wrap(err, failure.Message("POST /initialize: リクエストに失敗しました"))
 	}
 	defer res.Body.Close()
 	defer io.Copy(ioutil.Discard, res.Body)
@@ -44,10 +48,20 @@ func (c *Client) Initialize(ctx context.Context) error {
 	// MEMO: /initializeの成功ステータスによって第二引数が変わる可能性がある
 	err = checkStatusCode(res, []int{http.StatusOK})
 	if err != nil {
-		return failure.Wrap(err, failure.Message("POST /initialize: レスポンスコードが不正です"))
+		return nil, failure.Wrap(err, failure.Message("POST /initialize: レスポンスコードが不正です"))
 	}
 
-	return nil
+	var initRes InitializeResponse
+
+	err = json.NewDecoder(res.Body).Decode(&initRes)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, failure.Wrap(err, failure.Message("POST /initialize: JSONデコードに失敗しました"))
+	}
+
+	return &initRes, nil
 }
 
 type ChairsResponse struct {

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -61,6 +61,10 @@ func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 		return nil, failure.Wrap(err, failure.Message("POST /initialize: JSONデコードに失敗しました"))
 	}
 
+	if initRes.Language == "" {
+		return nil, failure.New(fails.ErrApplication, failure.Message("POST /initialize: 実装言語が設定されていません"))
+	}
+
 	return &initRes, nil
 }
 

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -23,6 +23,7 @@ type Output struct {
 	Pass     bool     `json:"pass"`
 	Score    int      `json:"score"`
 	Messages []string `json:"messages"`
+	Language string   `json:"language"`
 }
 
 type Config struct {
@@ -71,6 +72,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: eMsgs,
+			Language: "",
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 
@@ -79,7 +81,7 @@ func main() {
 
 	log.Print("=== initialize ===")
 	// 初期化：/initialize にリクエストを送ることで、外部リソースのURLを指定する・DBのデータを初期データのみにする
-	scenario.Initialize(context.Background())
+	initRes := scenario.Initialize(context.Background())
 	eMsgs = fails.ErrorsForCheck.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("initialize failed")
@@ -88,6 +90,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: eMsgs,
+			Language: initRes.Language,
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 
@@ -105,6 +108,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: uniqMsgs(eMsgs),
+			Language: initRes.Language,
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 
@@ -129,6 +133,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: uniqMsgs(eMsgs),
+			Language: initRes.Language,
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 
@@ -148,6 +153,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: uniqMsgs(eMsgs),
+			Language: initRes.Language,
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 
@@ -158,6 +164,7 @@ func main() {
 		Pass:     true,
 		Score:    score,
 		Messages: uniqMsgs(eMsgs),
+		Language: initRes.Language,
 	}
 	json.NewEncoder(os.Stdout).Encode(output)
 }

--- a/bench/scenario/normal.go
+++ b/bench/scenario/normal.go
@@ -6,11 +6,11 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 )
 
-func initialize(ctx context.Context) error {
+func initialize(ctx context.Context) (*client.InitializeResponse, error) {
 	c := client.NewClientForInitialize()
-	err := c.Initialize(ctx)
+	res, err := c.Initialize(ctx)
 	if err != nil {
-		return err
+		return res, err
 	}
-	return nil
+	return res, nil
 }

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -3,11 +3,12 @@ package scenario
 import (
 	"context"
 
+	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 )
 
-func Initialize(ctx context.Context) {
+func Initialize(ctx context.Context) (*client.InitializeResponse) {
 	// Initializeにはタイムアウトを設定
 	// レギュレーションにある時間を設定する
 	// timeoutSeconds := 180
@@ -15,10 +16,11 @@ func Initialize(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, paramater.InitializeTimeout)
 	defer cancel()
 
-	err := initialize(ctx)
+	res, err := initialize(ctx)
 	if err != nil {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfInitialize)
 	}
+	return res
 }
 
 func Validation(ctx context.Context) {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -193,6 +193,10 @@ var ChairDepthRanges = []*Range{
 	},
 }
 
+type InitializeResponse struct {
+	Language string `json:"language"`
+}
+
 type Chair struct {
 	ID          int64  `db:"id" json:"id"`
 	Name        string `db:"name" json:"name"`
@@ -385,7 +389,9 @@ func initialize(c echo.Context) error {
 		}
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.JSON(http.StatusOK, InitializeResponse{
+		Language: "go",
+	})
 }
 
 func getChairDetail(c echo.Context) error {


### PR DESCRIPTION
## 目的

- 使用された言語の割合を算出するため、各 job ごとに使用言語を取得する


## 解決方法

- `POST /initialize` のレスポンスとして、使用言語を返すようにした


## 動作確認

- [x] ベンチマーカーの結果出力に使用言語が含まれていることを確認


## 参考文献 (Optional)

- なし
