### PR TITLE
[webapp/mysql] MySQL特有の記法を減らし、SQLに寄せる

### DIFF
--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -22,7 +22,6 @@ CHAIR_MIN_CENTIMETER = 30
 CHAIR_MAX_CENTIMETER = 200
 MIN_VIEW_COUNT = 3000
 MAX_VIEW_COUNT = 1000000
-sqlCommands = "use isuumo;\n"
 
 CHAIR_COLOR_LIST = [
     "黒",
@@ -167,7 +166,6 @@ if __name__ == "__main__":
         desc_lines = description_lines.readlines()
 
     with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
-        sqlfile.write(sqlCommands)
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -193,7 +191,7 @@ if __name__ == "__main__":
             })
         ]
 
-        sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
+        sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
         sqlfile.write(sqlCommand)
         txtfile.write(
             "\n".join([dump_chair_to_json_str(chair) for chair in CHAIRS_FOR_VERIFY]) + "\n")
@@ -204,7 +202,7 @@ if __name__ == "__main__":
             bulk_list = [generate_chair_dummy_data(
                 chair_id + i) for i in range(BULK_INSERT_COUNT)]
             chair_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
+            sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
             sqlfile.write(sqlCommand)
 
             txtfile.write(

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -22,7 +22,6 @@ DOOR_MIN_CENTIMETER = 30
 DOOR_MAX_CENTIMETER = 200
 MIN_VIEW_COUNT = 3000
 MAX_VIEW_COUNT = 1000000
-sqlCommands = "use isuumo;\n"
 
 BUILDING_NAME_LIST = [
     "{name}ISUビルディング",
@@ -102,7 +101,6 @@ if __name__ == '__main__':
         desc_lines = description_lines.readlines()
 
     with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
-        sqlfile.write(sqlCommands)
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -122,7 +120,7 @@ if __name__ == '__main__':
             })
         ]
 
-        sqlCommand = f"""INSERT INTO estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", ESTATES_FOR_VERIFY))};"""
+        sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", ESTATES_FOR_VERIFY))};"""
         sqlfile.write(sqlCommand)
         txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                  for estate in ESTATES_FOR_VERIFY]) + "\n")
@@ -133,7 +131,7 @@ if __name__ == '__main__':
             bulk_list = [generate_estate_dummy_data(
                 estate_id + i) for i in range(BULK_INSERT_COUNT)]
             estate_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", bulk_list))};"""
+            sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", bulk_list))};"""
             sqlfile.write(sqlCommand)
             txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                      for estate in bulk_list]) + "\n")

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -1,38 +1,36 @@
 DROP DATABASE IF EXISTS isuumo;
-CREATE DATABASE isuumo DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE isuumo;
 
-USE isuumo;
+DROP TABLE IF EXISTS isuumo.estate;
+DROP TABLE IF EXISTS isuumo.chair;
 
-DROP TABLE IF EXISTS estate;
-DROP TABLE IF EXISTS chair;
+CREATE TABLE isuumo.estate (
+    id INTEGER PRIMARY KEY,
+    thumbnail VARCHAR(256) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    address VARCHAR(128) NOT NULL,
+    rent INTEGER NOT NULL,
+    door_height INTEGER NOT NULL,
+    door_width INTEGER NOT NULL,
+    view_count INTEGER DEFAULT 0 NOT NULL,
+    description TEXT NOT NULL,
+    features VARCHAR(256) NOT NULL
+);
 
-CREATE TABLE estate (
-    `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
-    `thumbnail` VARCHAR(256) NOT NULL,
-    `name` VARCHAR(64) NOT NULL,
-    `latitude` DOUBLE NOT NULL,
-    `longitude` DOUBLE NOT NULL,
-    `address` VARCHAR(128) NOT NULL,
-    `rent` INTEGER NOT NULL,
-    `door_height` INTEGER NOT NULL,
-    `door_width` INTEGER NOT NULL,
-    `view_count` INTEGER DEFAULT 0 NOT NULL,
-    `description` TEXT NOT NULL,
-    `features` VARCHAR(256) NOT NULL
-)ENGINE=InnoDB;
-
-CREATE TABLE chair (
-    `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
-    `thumbnail` TEXT,
-    `name` VARCHAR(64) NOT NULL,
-    `description` TEXT NOT NULL,
-    `price` INTEGER NOT NULL,
-    `height` INTEGER NOT NULL,
-    `width` INTEGER NOT NULL,
-    `depth` INTEGER NOT NULL,
-    `view_count` INTEGER NOT NULL DEFAULT 0,
-    `stock` INTEGER NOT NULL DEFAULT 0,
-    `color` VARCHAR(64) NOT NULL,
-    `features` VARCHAR(64) NOT NULL,
-    `kind` VARCHAR(64) NOT NULL
-)ENGINE=InnoDB;
+CREATE TABLE isuumo.chair (
+    id INTEGER PRIMARY KEY,
+    thumbnail TEXT,
+    name VARCHAR(64) NOT NULL,
+    description TEXT NOT NULL,
+    price INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    width INTEGER NOT NULL,
+    depth INTEGER NOT NULL,
+    view_count INTEGER NOT NULL DEFAULT 0,
+    stock INTEGER NOT NULL DEFAULT 0,
+    color VARCHAR(64) NOT NULL,
+    features VARCHAR(64) NOT NULL,
+    kind VARCHAR(64) NOT NULL
+);

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -4,33 +4,35 @@ CREATE DATABASE isuumo;
 DROP TABLE IF EXISTS isuumo.estate;
 DROP TABLE IF EXISTS isuumo.chair;
 
-CREATE TABLE isuumo.estate (
-    id INTEGER PRIMARY KEY,
-    thumbnail VARCHAR(256) NOT NULL,
-    name VARCHAR(64) NOT NULL,
-    latitude DOUBLE PRECISION NOT NULL,
-    longitude DOUBLE PRECISION NOT NULL,
-    address VARCHAR(128) NOT NULL,
-    rent INTEGER NOT NULL,
-    door_height INTEGER NOT NULL,
-    door_width INTEGER NOT NULL,
-    view_count INTEGER DEFAULT 0 NOT NULL,
-    description TEXT NOT NULL,
-    features VARCHAR(256) NOT NULL
+CREATE TABLE isuumo.estate
+(
+    id          INTEGER             NOT NULL PRIMARY KEY,
+    name        VARCHAR(64)         NOT NULL,
+    description VARCHAR(4096)       NOT NULL,
+    thumbnail   VARCHAR(128)        NOT NULL,
+    address     VARCHAR(128)        NOT NULL,
+    latitude    DOUBLE PRECISION    NOT NULL,
+    longitude   DOUBLE PRECISION    NOT NULL,
+    rent        INTEGER             NOT NULL,
+    door_height INTEGER             NOT NULL,
+    door_width  INTEGER             NOT NULL,
+    features    VARCHAR(64)         NOT NULL,
+    view_count  INTEGER             NOT NULL
 );
 
-CREATE TABLE isuumo.chair (
-    id INTEGER PRIMARY KEY,
-    thumbnail TEXT,
-    name VARCHAR(64) NOT NULL,
-    description TEXT NOT NULL,
-    price INTEGER NOT NULL,
-    height INTEGER NOT NULL,
-    width INTEGER NOT NULL,
-    depth INTEGER NOT NULL,
-    view_count INTEGER NOT NULL DEFAULT 0,
-    stock INTEGER NOT NULL DEFAULT 0,
-    color VARCHAR(64) NOT NULL,
-    features VARCHAR(64) NOT NULL,
-    kind VARCHAR(64) NOT NULL
+CREATE TABLE isuumo.chair
+(
+    id          INTEGER         NOT NULL PRIMARY KEY,
+    name        VARCHAR(64)     NOT NULL,
+    description VARCHAR(4096)   NOT NULL,
+    thumbnail   VARCHAR(128)    NOT NULL,
+    price       INTEGER         NOT NULL,
+    height      INTEGER         NOT NULL,
+    width       INTEGER         NOT NULL,
+    depth       INTEGER         NOT NULL,
+    color       VARCHAR(64)     NOT NULL,
+    features    VARCHAR(64)     NOT NULL,
+    kind        VARCHAR(64)     NOT NULL,
+    view_count  INTEGER         NOT NULL,
+    stock       INTEGER         NOT NULL
 );


### PR DESCRIPTION
## 目的

- PostGIS を使用していることから MySQL から PostgreSQL への移行を考える競技者が現れる可能性がある
- 現状の SQL ファイルは MySQL 特有の記述が多く、 PostgreSQL で動かすためには多くの修正が必要になる
- ただでさえ PostgreSQL への移行に時間がかかることから、このような手間は最小限に抑えておく
- #32 のやり直し


## 解決方法

- MySQL 特有の記法を減らした


## 動作確認

- [x] `/initialize` によりデータが初期化されていることを確認


## 参考文献 (Optional)

- なし
