### PR TITLE
[bench] POST /initializeのTimeoutを30秒に変更

### DIFF
--- a/bench/paramater/paramater.go
+++ b/bench/paramater/paramater.go
@@ -22,7 +22,7 @@ const (
 	IntervalForCheckWorkers               = 5 * time.Second
 	ThresholdTimeOfAbandonmentPage        = 1 * time.Second
 	DefaultAPITimeout                     = 2000 * time.Millisecond
-	InitializeTimeout                     = 180 * time.Second
+	InitializeTimeout                     = 30 * time.Second
 	VerifyTimeout                         = 10 * time.Second
 	LoadTimeout                           = 60 * time.Second
 )


### PR DESCRIPTION
## 目的

- データ件数を (10 ** 4) * 3 件に設定したため、 `POST /initialize` は初期状態で 15 秒ほどで終わるようになった
- 現行での `POST /initialize` の Timeout は 3 分に設定されていた
	- 余った時間を使って `POST /initialize` の中で重い処理ができてしまう


## 解決方法

- `POST /initialize` の Timeout を 30 秒に変更


## 動作確認

- [x] `POST /initialize`　に 30 秒以上かかるとタイムアウトすることを確認


## 参考文献 (Optional)

- なし
