### PR TITLE
[webapp/mysql] DBを初期化するためのシェルスクリプトを追加

### DIFF
--- a/webapp/mysql/db/init.sh
+++ b/webapp/mysql/db/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -xe
+set -o pipefail
+
+CURRENT_DIR=$(cd $(dirname $0);pwd)
+export MYSQL_HOST=${MYSQL_HOST:-127.0.0.1}
+export MYSQL_PORT=${MYSQL_PORT:-3306}
+export MYSQL_USER=${MYSQL_USER:-isucon}
+export MYSQL_DBNAME=${MYSQL_DBNAME:-isuumo}
+export MYSQL_PWD=${MYSQL_PASS:-isucon}
+export LANG="C.UTF-8"
+cd $CURRENT_DIR
+
+cat 0_Schema.sql 1_DummyEstateData.sql 2_DummyChairData.sql | mysql --defaults-file=/dev/null -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USER $MYSQL_DBNAME


### PR DESCRIPTION
## 目的

- 競技者が DB を初期状態に戻すための方法が明記されていなかった


## 解決方法

- `./webapp/mysql/db/init.sh` で DB を初期化できるように変更


## 動作確認

- [x] GCP インスタンス上で DB が初期化できることを確認


## 参考文献 (Optional)

- https://github.com/isucon/isucon9-qualify/blob/master/webapp/sql/init.sh
