### PR TITLE
[bench] イスが売り切れていた際に、シナリオがエラーを返すのを修正

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -175,9 +175,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	if chair == nil {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: イス情報が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
+		return nil
 	}
 
 	if !isChairEqualToAsset(chair) {


### PR DESCRIPTION
## 目的

- イス検索シナリオにて、イスの詳細を取得する直前にイスが売り切れていた場合にエラーがごく稀に発生していた

```
2020/08/03 17:33:21 fails.go:102: [scenario.chairSearchScenario] bench/scenario/chairSearchScenario.go:151
    message("GET /api/chair/:id: イス情報が不正です")
    code(error application)
[CallStack]
    [scenario.chairSearchScenario] bench/scenario/chairSearchScenario.go:151
    [scenario.runChairSearchWorker] bench/scenario/load.go:65
    [runtime.goexit] /usr/local/Cellar/go/1.14.5/libexec/src/runtime/asm_amd64.s:1373
```


## 解決方法

- イスが売り切れていた際にはシナリオを即座に再実行するように修正


## 動作確認

- [x] エラーが発生しないことを確認


## 参考文献 (Optional)

- なし
