### PR TITLE
[bench] イスの在庫数の更新を遅らせる

### DIFF
--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -133,6 +133,9 @@ func IncrementChairViewCount(id int64) {
 
 func DecrementChairStock(ctx context.Context, id int64) {
 	if ExistsChairInMap(id) {
+		// イスが売り切れた時点で走っている検索結果等にそのイスが含まれている可能性がある
+		// 検索結果のcheckが落ちないように、確実に検索結果に含まれないであろう時間まで待ってから在庫を減らす
+		// checkされる結果はすべてparamater.SleepTimeOnUserAway以下の時間で終了している
 		timer := time.NewTimer(paramater.SleepTimeOnUserAway)
 		select {
 		case <-timer.C:

--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
 	"github.com/morikuni/failure"
 	"golang.org/x/sync/errgroup"
 )
@@ -129,9 +131,15 @@ func IncrementChairViewCount(id int64) {
 	}
 }
 
-func DecrementChairStock(id int64) {
+func DecrementChairStock(ctx context.Context, id int64) {
 	if ExistsChairInMap(id) {
-		chairMap[id].DecrementStock()
+		timer := time.NewTimer(paramater.SleepTimeOnUserAway)
+		select {
+		case <-timer.C:
+			chairMap[id].DecrementStock()
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -536,7 +536,7 @@ func (c *Client) BuyChair(ctx context.Context, id string) error {
 	}
 
 	intid, _ := strconv.ParseInt(id, 10, 64)
-	asset.DecrementChairStock(intid)
+	asset.DecrementChairStock(ctx, intid)
 	if !c.isBot {
 		conversion.IncrementCount()
 	}


### PR DESCRIPTION
## 目的

- `GET /api/chair/search` の response body の check に失敗することが多かった
- 原因を調査してみたところ、 `GET /api/chair/search` と `POST /api/chair/buy/:id` のタイミングが悪いことがわかった

```
2020/08/05 11:00:04 check.go:52: id: 6438, stock: 0, last update: 31.451753ms, check time: 4.914µs
2020/08/05 11:00:04 chairSearchScenario.go:106: chair search request duration: 203.165853ms
2020/08/05 11:00:04 fails.go:102: [scenario.chairSearchScenario] bench/scenario/chairSearchScenario.go:107
    message("GET /api/chair/search: 検索結果が不正です")
    code(error application)
```

![image](https://user-images.githubusercontent.com/19568747/89364740-1e888980-d70e-11ea-82bc-6b252afc73d7.png)

- `GET /api/chair/search` 中に `POST /api/chair/buy/:id` が成功しているため、 `asset` 内の `chair.stock` が更新されていた
- `GET /api/chair/search` 後の `isChairsOrderedByViewCount` で `chair.stock` が参照される
	- `GET /api/chair/search` は `webapp/mysql` 内の更新前の `chair.stock` を参照している
	- `isChairsOrderedByViewCount` は `bench/asset` 内の更新後の `chair.stock` を参照している
- これにより差異が生まれてしまい、 check に失敗することがわかった


## 解決方法

![image](https://user-images.githubusercontent.com/19568747/89364711-06186f00-d70e-11ea-8a24-e883365b011e.png)

- `chair.stock` に関しては、検索結果に含まれるイスの `chair.stock` が 0 以下の際だけ落ちる
	- 1 以上であればエラーは起きない
- `isChairsOrderedByViewCount` で検査する `chair.stock` の情報を **確実に** 売り切れている商品が入っていないこととする
- `isChairsOrderedByViewCount` は `paramater.SleepTimeOnUserAway` 以下の時間で終わる `GET: /api/chair/search` にしか実行されない
- よって、 `POST: /api/chair/buy/:id` してから `paramater.SleepTimeOnUserAway` 後に `asset` の `chair.stock` を更新すれば、確実に売り切れている判定になる


## 動作確認

- [x] 複数回ベンチマークを回して `GET /api/chair/search: 検索結果が不正です` が出ないことを確認


## 参考文献 (Optional)

- なし
