### PR TITLE
[bench] body read時のTimeoutメッセージをrequest時のTimeoutメッセージに揃える

### DIFF
--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -120,8 +119,8 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/chair/:id: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/:id: JSONデコードに失敗しました"))
 	}
@@ -161,8 +160,8 @@ func (c *Client) GetChairSearchCondition(ctx context.Context) (*asset.ChairSearc
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/chair/search/condition: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/search/condition: JSONデコードに失敗しました"))
 	}
@@ -203,8 +202,8 @@ func (c *Client) SearchChairsWithQuery(ctx context.Context, q url.Values) (*Chai
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/chair/search: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/search: JSONデコードに失敗しました"))
 	}
@@ -242,8 +241,8 @@ func (c *Client) GetEstateSearchCondition(ctx context.Context) (*asset.EstateSea
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/estate/search/condition: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/search/condition: JSONデコードに失敗しました"))
 	}
@@ -284,8 +283,8 @@ func (c *Client) SearchEstatesWithQuery(ctx context.Context, q url.Values) (*Est
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/estate/search: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/search: JSONデコードに失敗しました"))
 	}
@@ -331,8 +330,8 @@ func (c *Client) SearchEstatesNazotte(ctx context.Context, polygon *Coordinates)
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("POST /api/estate/nazotte: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("POST /api/estate/nazotte: JSONデコードに失敗しました"))
 	}
@@ -373,8 +372,8 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/estate/:id: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/:id: JSONデコードに失敗しました"))
 	}
@@ -417,8 +416,8 @@ func (c *Client) GetRecommendedChair(ctx context.Context) (*ChairsResponse, erro
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/recommended_chair: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_chair: JSONデコードに失敗しました"))
 	}
@@ -459,8 +458,8 @@ func (c *Client) GetRecommendedEstate(ctx context.Context) (*EstatesResponse, er
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/recommended_estate: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate: JSONデコードに失敗しました"))
 	}
@@ -501,8 +500,8 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			err = failure.Translate(nerr, fails.ErrTimeout)
+		if nerr, ok := err.(interface{ Timeout() bool }); ok && nerr.Timeout() {
+			return nil, failure.Translate(err, fails.ErrTimeout, failure.Message("GET /api/recommended_estate/:id: リクエストに失敗しました"))
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/recommended_estate/:id: JSONデコードに失敗しました"))
 	}


### PR DESCRIPTION
## 目的

- 競技者から見て、リクエスト時にタイムアウトしているのと、そのレスポンスを benchmarker で読み込み時にタイムアウトしているのでは、レスポンスが遅いという点では大差ないエラーである
- しかし、エラーメッセージは別々の出力がなされていた


## 解決方法

- 混乱を防ぐため、同一のエラーメッセージに統一する


## 動作確認

- [x] エラーメッセージが統一されていることを benchmarker の出力から確認


## 参考文献 (Optional)

- なし
