### PR TITLE
[bench] イスが売り切れているかをtimeからも判断する

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -101,7 +101,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return nil
 	}
 
-	if !isChairsOrderedByViewCount(cr.Chairs) {
+	if !isChairsOrderedByViewCount(cr.Chairs, t) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -129,7 +129,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isChairsOrderedByViewCount(cr.Chairs) {
+			if !isChairsOrderedByViewCount(cr.Chairs, t) {
 				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)

--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -1,6 +1,8 @@
 package scenario
 
 import (
+	"time"
+
 	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 )
 
@@ -36,7 +38,19 @@ func isChairEqualToAsset(c *asset.Chair) bool {
 	return chair.Equal(c)
 }
 
-func isChairsOrderedByViewCount(c []asset.Chair) bool {
+func isChairSoldOutAt(c *asset.Chair, t time.Time) bool {
+	if c.GetStock() > 0 {
+		return false
+	}
+
+	soldOutTime := c.GetSoldOutTime()
+	if soldOutTime == nil {
+		return false
+	}
+	return t.After(*soldOutTime)
+}
+
+func isChairsOrderedByViewCount(c []asset.Chair, t time.Time) bool {
 	var viewCount int64 = -1
 	for i, chair := range c {
 		_chair, err := asset.GetChairFromID(chair.ID)
@@ -44,7 +58,7 @@ func isChairsOrderedByViewCount(c []asset.Chair) bool {
 			return false
 		}
 
-		if _chair.GetStock() <= 0 {
+		if isChairSoldOutAt(_chair, t) {
 			return false
 		}
 


### PR DESCRIPTION
## 目的

- #43 の別の解決案
- `GET /api/chair/search` とイスの売り切れた時間を比較する


## 解決方法

- `GET /api/chair/search` を送ったときの `time` が、 イスの売り切れた時間より後ならば check に失敗するように変更


## 動作確認

- [x] 複数回ベンチマークを回して GET /api/chair/search: 検索結果が不正です が出ないことを確認
- [x] `time` の比較で、落ちるはずだった check が落ちなくなったことを確認


## 参考文献 (Optional)

- なし
