### PR TITLE
[bench] metricを削除

### DIFF
--- a/bench/metric/metric.go
+++ b/bench/metric/metric.go
@@ -1,4 +1,0 @@
-package metric
-
-type Metric struct {
-}


### PR DESCRIPTION
## 目的

- ほとんど何も記述されていない `metric` という package があった


## 解決方法

- `metric` ディレクトリを削除した


## 動作確認

- [x] `bench` のビルドに成功することを確認


## 参考文献 (Optional)

- なし
