### PR TITLE
[bench] paramaterをparameterに変更

### DIFF
--- a/bench/client/newclient.go
+++ b/bench/client/newclient.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
 
 func NewClient(userAgent string, isBot bool) *Client {
@@ -19,7 +19,7 @@ func NewClient(userAgent string, isBot bool) *Client {
 					ServerName: ShareTargetURLs.TargetHost,
 				},
 			},
-			Timeout: paramater.DefaultAPITimeout,
+			Timeout: parameter.DefaultAPITimeout,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return fmt.Errorf("redirect attempted")
 			},
@@ -56,7 +56,7 @@ func NewClientForVerify() *Client {
 					ServerName: ShareTargetURLs.TargetHost,
 				},
 			},
-			Timeout: paramater.VerifyTimeout,
+			Timeout: parameter.VerifyTimeout,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return fmt.Errorf("redirect attempted")
 			},

--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -1,4 +1,4 @@
-package paramater
+package parameter
 
 import "time"
 

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -13,7 +13,7 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
 
 func createRandomChairSearchQuery() (url.Values, error) {
@@ -52,7 +52,7 @@ func createRandomChairSearchQuery() (url.Values, error) {
 	featureLength := rand.Intn(len(features)-1) + 1
 	q.Set("features", strings.Join(features[:featureLength], ","))
 
-	q.Set("perPage", strconv.Itoa(paramater.PerPageOfChairSearch))
+	q.Set("perPage", strconv.Itoa(parameter.PerPageOfChairSearch))
 	q.Set("page", "0")
 
 	return q, nil
@@ -65,7 +65,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -75,7 +75,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -93,7 +93,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -107,10 +107,10 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	numOfPages := int(cr.Count) / paramater.PerPageOfChairSearch
+	numOfPages := int(cr.Count) / parameter.PerPageOfChairSearch
 
 	if numOfPages != 0 {
-		for i := 0; i < paramater.NumOfCheckChairSearchPaging; i++ {
+		for i := 0; i < parameter.NumOfCheckChairSearchPaging; i++ {
 			q.Set("page", strconv.Itoa(rand.Intn(numOfPages)))
 
 			t := time.Now()
@@ -120,7 +120,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+			if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 				return failure.New(fails.ErrTimeout)
 			}
 
@@ -134,7 +134,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
-			numOfPages = int(cr.Count) / paramater.PerPageOfChairSearch
+			numOfPages = int(cr.Count) / parameter.PerPageOfChairSearch
 			if numOfPages == 0 {
 				break
 			}
@@ -152,7 +152,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -191,7 +191,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -12,7 +12,7 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
 
 type point struct {
@@ -132,10 +132,10 @@ func ToCoordinates(po []point) *client.Coordinates {
 // 点Pの周りの4点を返す
 func getPointNeighbors(p point) []point {
 	return []point{
-		{Latitude: p.Latitude - paramater.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + paramater.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude + paramater.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + paramater.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude - paramater.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - paramater.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude + paramater.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - paramater.NeighborhoodRadiusOfNazotte},
+		{Latitude: p.Latitude - parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + parameter.NeighborhoodRadiusOfNazotte},
+		{Latitude: p.Latitude + parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + parameter.NeighborhoodRadiusOfNazotte},
+		{Latitude: p.Latitude - parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - parameter.NeighborhoodRadiusOfNazotte},
+		{Latitude: p.Latitude + parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - parameter.NeighborhoodRadiusOfNazotte},
 	}
 }
 
@@ -187,7 +187,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -197,7 +197,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -214,11 +214,11 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
-	if len(er.Estates) > paramater.MaxLengthOfNazotteResponse {
+	if len(er.Estates) > parameter.MaxLengthOfNazotteResponse {
 		err = failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -243,7 +243,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -13,7 +13,7 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
 
 var estateFeatureList = []string{
@@ -46,7 +46,7 @@ func createRandomEstateSearchQuery() (url.Values, error) {
 	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
 	featureLength := rand.Intn(len(features)-1) + 1
 	q.Set("features", strings.Join(features[:featureLength], ","))
-	q.Set("perPage", strconv.Itoa(paramater.PerPageOfEstateSearch))
+	q.Set("perPage", strconv.Itoa(parameter.PerPageOfEstateSearch))
 	q.Set("page", "0")
 
 	return q, nil
@@ -60,7 +60,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -70,7 +70,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -88,7 +88,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 
@@ -102,9 +102,9 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	numOfPages := int(er.Count) / paramater.PerPageOfEstateSearch
+	numOfPages := int(er.Count) / parameter.PerPageOfEstateSearch
 	if numOfPages != 0 {
-		for i := 0; i < paramater.NumOfCheckEstateSearchPaging; i++ {
+		for i := 0; i < parameter.NumOfCheckEstateSearchPaging; i++ {
 			q.Set("page", strconv.Itoa(rand.Intn(numOfPages)))
 
 			t := time.Now()
@@ -114,7 +114,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+			if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 				return failure.New(fails.ErrTimeout)
 			}
 
@@ -128,7 +128,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
-			numOfPages = int(er.Count) / paramater.PerPageOfEstateSearch
+			numOfPages = int(er.Count) / parameter.PerPageOfEstateSearch
 			if numOfPages == 0 {
 				break
 			}
@@ -145,7 +145,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if time.Since(t) > paramater.ThresholdTimeOfAbandonmentPage {
+	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
 		return failure.New(fails.ErrTimeout)
 	}
 

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 	"github.com/morikuni/failure"
 	"github.com/google/uuid"
 )
@@ -31,12 +31,12 @@ func runEstateSearchWorker(ctx context.Context) {
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {
-				r := rand.Intn(paramater.SleepSwingOnUserAway) - paramater.SleepSwingOnUserAway*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnUserAway) - parameter.SleepSwingOnUserAway*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			} else {
-				r := rand.Intn(paramater.SleepSwingOnFailScenario) - paramater.SleepSwingOnFailScenario*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnFailScenario) - parameter.SleepSwingOnFailScenario*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			}
 			select {
@@ -66,12 +66,12 @@ func runChairSearchWorker(ctx context.Context) {
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {
-				r := rand.Intn(paramater.SleepSwingOnUserAway) - paramater.SleepSwingOnUserAway*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnUserAway) - parameter.SleepSwingOnUserAway*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			} else {
-				r := rand.Intn(paramater.SleepSwingOnFailScenario) - paramater.SleepSwingOnFailScenario*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnFailScenario) - parameter.SleepSwingOnFailScenario*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			}
 			select {
@@ -101,12 +101,12 @@ func runEstateNazotteSearchWorker(ctx context.Context) {
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code == fails.ErrTimeout {
-				r := rand.Intn(paramater.SleepSwingOnUserAway) - paramater.SleepSwingOnUserAway*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnUserAway) - parameter.SleepSwingOnUserAway*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			} else {
-				r := rand.Intn(paramater.SleepSwingOnFailScenario) - paramater.SleepSwingOnFailScenario*0.5
-				s := paramater.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
+				r := rand.Intn(parameter.SleepSwingOnFailScenario) - parameter.SleepSwingOnFailScenario*0.5
+				s := parameter.SleepTimeOnFailScenario + time.Duration(r)*time.Millisecond
 				t = time.NewTimer(s)
 			}
 			select {
@@ -125,8 +125,8 @@ func runBotWorker(ctx context.Context) {
 
 	for {
 		go botScenario(ctx, c)
-		r := rand.Intn(paramater.SleepSwingOnBotInterval) - paramater.SleepSwingOnBotInterval*0.5
-		s := paramater.SleepTimeOnBotInterval + time.Duration(r)*time.Millisecond
+		r := rand.Intn(parameter.SleepSwingOnBotInterval) - parameter.SleepSwingOnBotInterval*0.5
+		s := parameter.SleepTimeOnBotInterval + time.Duration(r)*time.Millisecond
 		t := time.NewTimer(s)
 		select {
 		case <-t.C:
@@ -138,16 +138,16 @@ func runBotWorker(ctx context.Context) {
 }
 
 func checkWorkers(ctx context.Context) {
-	t := time.NewTicker(paramater.IntervalForCheckWorkers)
+	t := time.NewTicker(parameter.IntervalForCheckWorkers)
 	for {
 		select {
 		case <-t.C:
 			cet := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfChairSearchScenario)
 			eet := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfEstateSearchScenario)
 			net := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfEstateNazotteSearchScenario)
-			if time.Since(cet) > paramater.IntervalForCheckWorkers &&
-				time.Since(eet) > paramater.IntervalForCheckWorkers &&
-				time.Since(net) > paramater.IntervalForCheckWorkers {
+			if time.Since(cet) > parameter.IntervalForCheckWorkers &&
+				time.Since(eet) > parameter.IntervalForCheckWorkers &&
+				time.Since(net) > parameter.IntervalForCheckWorkers {
 				log.Println("負荷レベルが上昇しました。")
 				go runChairSearchWorker(ctx)
 				go runEstateSearchWorker(ctx)
@@ -164,22 +164,22 @@ func checkWorkers(ctx context.Context) {
 
 func Load(ctx context.Context) {
 	// 物件検索をして、資料請求をするシナリオ
-	for i := 0; i < paramater.NumOfInitialEstateSearchWorker; i++ {
+	for i := 0; i < parameter.NumOfInitialEstateSearchWorker; i++ {
 		go runEstateSearchWorker(ctx)
 	}
 
 	// イス検索から物件ページに行き、資料請求をするまでのシナリオ
-	for i := 0; i < paramater.NumOfInitialChairSearchWorker; i++ {
+	for i := 0; i < parameter.NumOfInitialChairSearchWorker; i++ {
 		go runChairSearchWorker(ctx)
 	}
 
 	// なぞって検索をするシナリオ
-	for i := 0; i < paramater.NumOfInitialEstateNazotteSearchWorker; i++ {
+	for i := 0; i < parameter.NumOfInitialEstateNazotteSearchWorker; i++ {
 		go runEstateNazotteSearchWorker(ctx)
 	}
 
 	// ボットによる検索シナリオ
-	for i := 0; i < paramater.NumOfInitialBotWorker; i++ {
+	for i := 0; i < parameter.NumOfInitialBotWorker; i++ {
 		go runBotWorker(ctx)
 	}
 

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
-	"github.com/isucon10-qualify/isucon10-qualify/bench/paramater"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
 
 func Initialize(ctx context.Context) (*client.InitializeResponse) {
@@ -13,7 +13,7 @@ func Initialize(ctx context.Context) (*client.InitializeResponse) {
 	// レギュレーションにある時間を設定する
 	// timeoutSeconds := 180
 
-	ctx, cancel := context.WithTimeout(ctx, paramater.InitializeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, parameter.InitializeTimeout)
 	defer cancel()
 
 	res, err := initialize(ctx)
@@ -24,7 +24,7 @@ func Initialize(ctx context.Context) (*client.InitializeResponse) {
 }
 
 func Validation(ctx context.Context) {
-	cancelCtx, cancel := context.WithTimeout(ctx, paramater.LoadTimeout)
+	cancelCtx, cancel := context.WithTimeout(ctx, parameter.LoadTimeout)
 	defer cancel()
 	go Load(cancelCtx)
 	<-cancelCtx.Done()


### PR DESCRIPTION
## 目的

- `paramater` package は `parameter` の typo


## 解決方法

- typo を修正


## 動作確認

- [x] ベンチマーカーが変更前と同様の挙動をすることを確認


## 参考文献 (Optional)

- なし
