### PR TITLE
[bench] 最終的な負荷レベルを結果として出力する

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -124,6 +124,7 @@ func main() {
 	// checkとloadは区別がつかないようにしないといけない。loadのリクエストはログアウト状態しかなかったので、ログアウト時のキャッシュを強くするだけでスコアがはねる問題が過去にあった
 	// 今回はほぼ全リクエストがログイン前提になっているので、checkとloadの区別はできないはず
 	scenario.Validation(context.Background())
+	log.Printf("最終的な負荷レベル: %d", scenario.GetLoadLevel())
 
 	// context.Canceledのエラーは直後に取れば基本的には入ってこない
 	eMsgs, cCnt, aCnt, _ := fails.ErrorsForCheck.Get()

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -5,14 +5,25 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 	"github.com/morikuni/failure"
-	"github.com/google/uuid"
 )
+
+var loadLevel int64
+
+func GetLoadLevel() int64 {
+	return atomic.LoadInt64(&loadLevel)
+}
+
+func IncrementLoadLevel() {
+	atomic.AddInt64(&loadLevel, 1)
+}
 
 func runEstateSearchWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
@@ -152,6 +163,7 @@ func checkWorkers(ctx context.Context) {
 				go runChairSearchWorker(ctx)
 				go runEstateSearchWorker(ctx)
 				go runEstateNazotteSearchWorker(ctx)
+				IncrementLoadLevel()
 			} else {
 				log.Println("シナリオ内でエラーが発生したため負荷レベルを上げられませんでした。")
 			}


### PR DESCRIPTION
## 目的

- workload がどこまで増加したのかを一目で確認する術がなかった (#52)


## 解決方法

- ベンチマーカーの最終的な出力に不可レベルを含めるように変更


## 動作確認

- [x] ベンチマーカーの出力に「最終的な負荷レベル」が含まれていることを確認

```
2020/08/11 11:09:03 bench.go:127: 最終的な負荷レベル: 4
2020/08/11 11:09:03 bench.go:150: 459 0
{"pass":true,"score":459,"messages":["POST /api/estate/nazotte: リクエストに失敗しました（タイムアウトしました）"],"language":"go"}
```


## 参考文献 (Optional)

- なし
