### PR TITLE
[webapp/go] イス購入と物件資料請求の処理を具体化する

### DIFF
--- a/bench/client/client.go
+++ b/bench/client/client.go
@@ -142,9 +142,13 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	if  !c.isBot && res.StatusCode == http.StatusServiceUnavailable {
+	if !c.isBot && res.StatusCode == http.StatusServiceUnavailable {
 		return nil, failure.New(fails.ErrTemporary)
 	}
 
 	return res, nil
+}
+
+func (c *Client) GetEmail() string {
+	return fmt.Sprintf("%s@isucon.com", c.userAgent)
 }

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -509,8 +509,17 @@ func (c *Client) GetRecommendedEstatesFromChair(ctx context.Context, id int64) (
 	return &estate, nil
 }
 
+type EmailRequest struct {
+	Email string `json:"email"`
+}
+
 func (c *Client) BuyChair(ctx context.Context, id string) error {
-	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/chair/buy/"+id, nil)
+	jsonStr, err := json.Marshal(EmailRequest{Email: c.GetEmail()})
+	if err != nil {
+		return failure.Translate(err, fails.ErrBenchmarker)
+	}
+
+	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/chair/buy/"+id, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker)
 	}
@@ -545,7 +554,12 @@ func (c *Client) BuyChair(ctx context.Context, id string) error {
 }
 
 func (c *Client) RequestEstateDocument(ctx context.Context, id string) error {
-	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/estate/req_doc/"+id, nil)
+	jsonStr, err := json.Marshal(EmailRequest{Email: c.GetEmail()})
+	if err != nil {
+		return failure.Translate(err, fails.ErrBenchmarker)
+	}
+
+	req, err := c.newPostRequest(ShareTargetURLs.AppURL, "/api/estate/req_doc/"+id, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker)
 	}

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -462,7 +462,7 @@ func buyChair(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			c.Echo().Logger.Infof("buyChair chair id \"%v\" not found", id)
-			return c.NoContent(http.StatusBadRequest)
+			return c.NoContent(http.StatusNotFound)
 		}
 		c.Echo().Logger.Errorf("DB Execution Error: on getting a chair by id : %v", err)
 		return c.NoContent(http.StatusInternalServerError)

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -434,7 +434,23 @@ func searchChairs(c echo.Context) error {
 	return c.JSON(http.StatusOK, chairs)
 }
 
+func sendMail(mail string) {
+	// Not implemented
+}
+
 func buyChair(c echo.Context) error {
+	m := echo.Map{}
+	if err := c.Bind(&m); err != nil {
+		c.Echo().Logger.Infof("post request document failed : %v", err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	email, ok := m["email"].(string)
+	if !ok {
+		c.Echo().Logger.Info("post request document failed : email not found in request body")
+		return c.NoContent(http.StatusBadRequest)
+	}
+
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.Echo().Logger.Infof("post request document failed : %v", err)
@@ -469,6 +485,8 @@ func buyChair(c echo.Context) error {
 		c.Echo().Logger.Errorf("transaction commit error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
+
+	sendMail(email)
 	return c.NoContent(http.StatusOK)
 }
 
@@ -793,12 +811,25 @@ func searchEstateNazotte(c echo.Context) error {
 }
 
 func postEstateRequestDocument(c echo.Context) error {
+	m := echo.Map{}
+	if err := c.Bind(&m); err != nil {
+		c.Echo().Logger.Infof("post request document failed : %v", err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	email, ok := m["email"].(string)
+	if !ok {
+		c.Echo().Logger.Info("post request document failed : email not found in request body")
+		return c.NoContent(http.StatusBadRequest)
+	}
+
 	_, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.Echo().Logger.Infof("post request document failed : %v", err)
 		return c.NoContent(http.StatusBadRequest)
 	}
 
+	sendMail(email)
 	return c.NoContent(http.StatusOK)
 }
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -823,10 +823,22 @@ func postEstateRequestDocument(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	_, err := strconv.Atoi(c.Param("id"))
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.Echo().Logger.Infof("post request document failed : %v", err)
 		return c.NoContent(http.StatusBadRequest)
+	}
+
+	sqlstr := `SELECT * FROM estate WHERE id = ?`
+
+	estate := Estate{}
+	err = db.Get(&estate, sqlstr, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return c.NoContent(http.StatusNotFound)
+		}
+		c.Logger().Errorf("postEstateRequestDocument DB execution error : %v", err)
+		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	sendEmail(email)

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -434,7 +434,7 @@ func searchChairs(c echo.Context) error {
 	return c.JSON(http.StatusOK, chairs)
 }
 
-func sendMail(mail string) {
+func sendEmail(email string) {
 	// Not implemented
 }
 
@@ -486,7 +486,7 @@ func buyChair(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	sendMail(email)
+	sendEmail(email)
 	return c.NoContent(http.StatusOK)
 }
 
@@ -829,7 +829,7 @@ func postEstateRequestDocument(c echo.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
-	sendMail(email)
+	sendEmail(email)
 	return c.NoContent(http.StatusOK)
 }
 


### PR DESCRIPTION
## 目的

- イス購入と物件資料請求の処理が少なすぎるとの指摘を受けた (#56)


## 解決方法

- リクエストにて `email` を受け取り、 `sendEmail` 関数に投げておく
	- `sendEmail` 関数の中身は未実装とした
- 物件資料請求にて、物件が存在しているかを確認するようにした


## 動作確認

- [x] ベンチマーカーからのイス購入と物件資料請求のリクエストが成功していることを確認


## 参考文献 (Optional)

- なし
