### PR TITLE
[webapp] コネクションプールの最大数を10個に制限する

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -217,6 +217,7 @@ func main() {
 	if err != nil {
 		e.Logger.Fatalf("DB connection failed : %v", err)
 	}
+	db.SetMaxOpenConns(10)
 	defer db.Close()
 
 	// Start server

--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -18,6 +18,7 @@ const dbinfo = {
   user: process.env.MYSQL_USER ?? "isucon",
   password: process.env.MYSQL_PASS ?? "isucon",
   database: process.env.MYSQL_DBNAME ?? "isuumo",
+  connectionLimit: 10,
 };
 
 const app = express();


### PR DESCRIPTION
## 目的

- Go と Node.js の実装でコネクションプールの個数が異なっていた
- これによりスコアに差ができていた


## 解決方法

- コネクションプールの最大数を 10 個に揃えた


## 動作確認

- [x] 各実装でベンチマークが正常に終了することを確認


## 参考文献 (Optional)

- なし
