### PR TITLE
[webapp/nodejs] Debug logを出力する

### DIFF
--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const morgan = require("morgan");
 const mysql = require("mysql");
 const path = require("path");
 const cp = require("child_process");
@@ -25,6 +26,7 @@ const app = express();
 const db = mysql.createPool(dbinfo);
 app.set("db", db);
 
+app.use(morgan('combined'));
 app.use(express.json());
 app.post("/initialize", async (req, res, next) => {
   try {

--- a/webapp/nodejs/package-lock.json
+++ b/webapp/nodejs/package-lock.json
@@ -18,6 +18,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
@@ -305,6 +313,38 @@
         "mime-db": "1.44.0"
       }
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -333,6 +373,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "parseurl": {
       "version": "1.3.3",

--- a/webapp/nodejs/package.json
+++ b/webapp/nodejs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "DEBUG=express:* node app.js"
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
     "camelcase-keys": "^6.2.2",
     "debug": "^4.1.1",
     "express": "^4.17.1",
+    "morgan": "^1.10.0",
     "mysql": "^2.18.1"
   }
 }

--- a/webapp/nodejs/package.json
+++ b/webapp/nodejs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node app.js"
+    "start": "DEBUG=express:* node app.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 目的

- Go 言語では初期実装で Debug log が出力されている
- Node.js では出力されていないため性能に差が出ていた

```
2020/08/11 18:27:39 bench.go:127: 最終的な負荷レベル: 3
2020/08/11 18:27:39 bench.go:150: 410 0
{"pass":true,"score":410,"messages":["POST /api/estate/nazotte: リクエストに失敗しました（タイムアウトしました）"],"language":"go"}
```

```
2020/08/11 18:10:31 bench.go:127: 最終的な負荷レベル: 11
2020/08/11 18:10:31 bench.go:150: 1000 0
{"pass":true,"score":1000,"messages":["POST /api/estate/nazotte: リクエストに失敗しました（タイムアウトしました）"],"language":"nodejs"}
```


## 解決方法

- Node.js でも Debug log を出すように変更


## 動作確認

- [x] webapp/nodejs にベンチマークをかけたときに Debug log が出ることを確認


## 参考文献 (Optional)

- https://expressjs.com/ja/guide/debugging.html
