### PR TITLE
[initial-data] featuresの個数や検索時の指定数を調整

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -22,7 +22,7 @@ const (
 	IntervalForCheckWorkers               = 5 * time.Second
 	ThresholdTimeOfAbandonmentPage        = 1000 * time.Millisecond
 	DefaultAPITimeout                     = 2000 * time.Millisecond
-	InitializeTimeout                     = 60 * time.Second
+	InitializeTimeout                     = 30 * time.Second
 	VerifyTimeout                         = 10 * time.Second
 	LoadTimeout                           = 60 * time.Second
 )

--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -22,7 +22,7 @@ const (
 	IntervalForCheckWorkers               = 5 * time.Second
 	ThresholdTimeOfAbandonmentPage        = 1000 * time.Millisecond
 	DefaultAPITimeout                     = 2000 * time.Millisecond
-	InitializeTimeout                     = 30 * time.Second
+	InitializeTimeout                     = 60 * time.Second
 	VerifyTimeout                         = 10 * time.Second
 	LoadTimeout                           = 60 * time.Second
 )

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -49,7 +49,10 @@ func createRandomChairSearchQuery() (url.Values, error) {
 	features := make([]string, len(condition.Feature.List))
 	copy(features, condition.Feature.List)
 	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)-1) + 1
+	featureLength := rand.Intn(len(features)) + 1
+	if featureLength > 3 {
+		featureLength = rand.Intn(3) + 1
+	}
 	q.Set("features", strings.Join(features[:featureLength], ","))
 
 	q.Set("perPage", strconv.Itoa(parameter.PerPageOfChairSearch))

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -44,7 +44,10 @@ func createRandomEstateSearchQuery() (url.Values, error) {
 	features := make([]string, len(condition.Feature.List))
 	copy(features, condition.Feature.List)
 	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)-1) + 1
+	featureLength := rand.Intn(len(features)) + 1
+	if featureLength > 3 {
+		featureLength = rand.Intn(3) + 1
+	}
 	q.Set("features", strings.Join(features[:featureLength], ","))
 	q.Set("perPage", strconv.Itoa(parameter.PerPageOfEstateSearch))
 	q.Set("page", "0")

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -97,7 +97,47 @@ CHAIR_FEATURE_LIST = [
     "高さ調節可能",
     "通気性抜群",
     "メタルフレーム",
-    "低反発"
+    "低反発",
+    "木製",
+    "背もたれつき",
+    "回転可能",
+    "レザー製",
+    "昇降式",
+    "デザイナーズ",
+    "金属製",
+    "プラスチック製",
+    "法事用",
+    "和風",
+    "中華風",
+    "西洋風",
+    "イタリア製",
+    "国産",
+    "背もたれなし",
+    "ラテン風",
+    "布貼地",
+    "スチール製",
+    "メッシュ貼地",
+    "オフィス用",
+    "料理店用",
+    "自宅用",
+    "キャンプ用",
+    "クッション性抜群",
+    "モーター付き",
+    "ベッド一体型",
+    "ディスプレイ配置可能",
+    "ミニ机付き",
+    "スピーカー付属",
+    "中国製",
+    "アンティーク",
+    "折りたたみ可能",
+    "重さ500g以内",
+    "24回払い無金利",
+    "現代的デザイン",
+    "近代的なデザイン",
+    "ルネサンス的なデザイン",
+    "アームなし",
+    "オーダーメイド可能",
+    "ポリカーボネート製",
 ]
 
 CHAIR_FEATURE_FOR_VERIFY = "フットレスト付き"
@@ -152,7 +192,7 @@ def dump_chair_to_json_str(chair):
 
 
 def generate_chair_dummy_data(chair_id, wrap={}):
-    features_length = random.randint(0, len(CHAIR_FEATURE_LIST) - 1)
+    features_length = random.randint(0, min(3, len(CHAIR_FEATURE_LIST)))
     image_hash = fake.word(ext_word_list=CHAIR_IMAGE_HASH_LIST)
 
     chair = {

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -37,15 +37,55 @@ BUILDING_NAME_LIST = [
 ]
 
 ESTATE_FEATURE_LIST = [
-    "2階以上",
+    "最上階",
+    "防犯カメラ",
+    "ウォークインクローゼット",
+    "ワンルーム",
+    "ルーフバルコニー付",
+    "エアコン付き",
+    "駐輪場あり",
+    "プロパンガス",
     "駐車場あり",
-    "ロフトあり",
-    "DIY可能",
-    "インターネット無料",
+    "防音室",
+    "追い焚き風呂",
     "オートロック",
-    "バストイレ別",
-    "駅から徒歩5分",
-    "ペット飼育可能",
+    "即入居可",
+    "IHコンロ",
+    "敷地内駐車場",
+    "トランクルーム",
+    "角部屋",
+    "カスタマイズ可",
+    "DIY可",
+    "ロフト",
+    "シューズボックス",
+    "インターネット無料",
+    "地下室",
+    "敷地内ゴミ置場",
+    "管理人有り",
+    "宅配ボックス",
+    "ルームシェア可",
+    "セキュリティ会社加入済",
+    "メゾネット",
+    "女性限定",
+    "バイク置場あり",
+    "エレベーター",
+    "ペット相談可",
+    "洗面所独立",
+    "都市ガス",
+    "浴室乾燥機",
+    "インターネット接続可",
+    "テレビ・通信",
+    "専用庭",
+    "システムキッチン",
+    "高齢者歓迎",
+    "ケーブルテレビ",
+    "床下収納",
+    "バス・トイレ別",
+    "駐車場2台以上",
+    "楽器相談可",
+    "フローリング",
+    "オール電化",
+    "TVモニタ付きインタホン"
 ]
 
 ESTATE_FEATURE_FOR_VERIFY = "デザイナーズ物件"
@@ -93,7 +133,7 @@ def dump_estate_to_json_str(estate):
 
 def generate_estate_dummy_data(estate_id, wrap={}):
     latlng = fake.local_latlng(country_code='JP', coords_only=True)
-    feature_length = random.randint(0, len(ESTATE_FEATURE_LIST) - 1)
+    feature_length = random.randint(0, min(3, len(ESTATE_FEATURE_LIST)))
     image_hash = fake.word(ext_word_list=ESTATE_IMAGE_HASH_LIST)
 
     estate = {

--- a/initial-data/make_verification_data/chair.go
+++ b/initial-data/make_verification_data/chair.go
@@ -36,7 +36,10 @@ func createRandomChairSearchQuery(condition ChairSearchCondition) url.Values {
 	features := make([]string, len(condition.Feature.List)-1)
 	copy(features, condition.Feature.List[:len(condition.Feature.List)-1])
 	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)-1) + 1
+	featureLength := rand.Intn(len(features)) + 1
+	if featureLength > 3 {
+		featureLength = rand.Intn(3) + 1
+	}
 	q.Set("features", strings.Join(features[:featureLength], ","))
 
 	q.Set("perPage", strconv.Itoa(rand.Intn(30)+20))

--- a/initial-data/make_verification_data/estate.go
+++ b/initial-data/make_verification_data/estate.go
@@ -25,7 +25,10 @@ func createRandomEstateSearchQuery(condition EstateSearchCondition) url.Values {
 	features := make([]string, len(condition.Feature.List)-1)
 	copy(features, condition.Feature.List[:len(condition.Feature.List)-1])
 	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)-1) + 1
+	featureLength := rand.Intn(len(features)) + 1
+	if featureLength > 3 {
+		featureLength = rand.Intn(3) + 1
+	}
 	q.Set("features", strings.Join(features[:featureLength], ","))
 	q.Set("perPage", strconv.Itoa(rand.Intn(30)+20))
 	q.Set("page", "0")


### PR DESCRIPTION
## 目的

- #57 を解決する


## 解決方法

- 全件数: 10 ^ 4 * 3
- 1 件が含む特徴の個数: 0 ~ 3 (mean: 1.5)
- 特徴の個数: 49 (verify 用のものを除く)
- ある 1 つの特徴を持っている件数: 約 918 件 ((10 ^ 4 * 3) * 1.5 / 49)


## 動作確認

- [x] ベンチマークが通ることを確認


## 参考文献 (Optional)

- なし
