### PR TITLE
[webapp/go] イス・物件の詳細とイスの購入時にはロック読み取りをする

### DIFF
--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -22,7 +22,7 @@ func isEstatesOrderedByViewCount(e []asset.Estate) bool {
 			return false
 		}
 		vc := e.GetViewCount()
-		if i > 0 && viewCount-vc < -3 {
+		if i > 0 && viewCount <= vc {
 			return false
 		}
 		viewCount = vc


### PR DESCRIPTION
## 目的

- イス・物件の詳細とイスの購入における Transaction が無意味になっていた
- 更新に用いる値は lock される前に DB から取得した値を使っていた


## 解決方法

- `SELECT ... FOR UPDATE` を使用する


## 動作確認

- [x] ベンチマーク時に予期せぬエラーが発生しないことを確認


## 参考文献 (Optional)

- https://dev.mysql.com/doc/refman/5.6/ja/innodb-locking-reads.html
- https://github.com/jmoiron/sqlx/issues/412
