### PR TITLE
[initial-data] initialize用に更新される箇所のupdateのみのファイルを生成

### DIFF
--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -231,6 +231,7 @@ if __name__ == "__main__":
         desc_lines = description_lines.readlines()
 
     with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile, open(OUTPUT_UPDATE_SQL_FILE, mode='w', encoding='utf-8') as update_sqlfile:
+        update_sqlfile.write("START TRANSACTION;\n")
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -281,6 +282,7 @@ if __name__ == "__main__":
                 "UPDATE isuumo.chair SET stock = {}, view_count = {} WHERE id = {};".format(chair["stock"], chair["view_count"], chair["id"])
                 for chair in bulk_list
             ]) + "\n")
+        update_sqlfile.write("COMMIT;\n")
 
     with open(OUTPUT_FIXTURE_FILE, mode='w', encoding='utf-8') as fixture_file:
         fixture_file.write(json.dumps({

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -12,6 +12,7 @@ random.seed(19700101)
 
 DESCRIPTION_LINES_FILE = "./description.txt"
 OUTPUT_SQL_FILE = "./result/2_DummyChairData.sql"
+OUTPUT_UPDATE_SQL_FILE = "./result/4_InitializeChairData.sql"
 OUTPUT_TXT_FILE = "./result/chair_json.txt"
 OUTPUT_FIXTURE_FILE = "./result/chair_condition.json"
 CHAIR_IMAGE_ORIGIN_DIR = "./origin/chair"
@@ -229,7 +230,7 @@ if __name__ == "__main__":
     with open(DESCRIPTION_LINES_FILE, mode='r', encoding='utf-8') as description_lines:
         desc_lines = description_lines.readlines()
 
-    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
+    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile, open(OUTPUT_UPDATE_SQL_FILE, mode='w', encoding='utf-8') as update_sqlfile:
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -259,6 +260,10 @@ if __name__ == "__main__":
         sqlfile.write(sqlCommand)
         txtfile.write(
             "\n".join([dump_chair_to_json_str(chair) for chair in CHAIRS_FOR_VERIFY]) + "\n")
+        update_sqlfile.write("\n".join([
+            "UPDATE isuumo.chair SET stock = {}, view_count = {} WHERE id = {};".format(chair["stock"], chair["view_count"], chair["id"])
+            for chair in CHAIRS_FOR_VERIFY
+        ]) + "\n")
 
         chair_id += len(CHAIRS_FOR_VERIFY)
 
@@ -271,6 +276,11 @@ if __name__ == "__main__":
 
             txtfile.write(
                 "\n".join([dump_chair_to_json_str(chair) for chair in bulk_list]) + "\n")
+
+            update_sqlfile.write("\n".join([
+                "UPDATE isuumo.chair SET stock = {}, view_count = {} WHERE id = {};".format(chair["stock"], chair["view_count"], chair["id"])
+                for chair in bulk_list
+            ]) + "\n")
 
     with open(OUTPUT_FIXTURE_FILE, mode='w', encoding='utf-8') as fixture_file:
         fixture_file.write(json.dumps({

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -12,6 +12,7 @@ random.seed(19700101)
 
 DESCRIPTION_LINES_FILE = "./description.txt"
 OUTPUT_SQL_FILE = "./result/1_DummyEstateData.sql"
+OUTPUT_UPDATE_SQL_FILE = "./result/3_InitializeEstateData.sql"
 OUTPUT_TXT_FILE = "./result/estate_json.txt"
 OUTPUT_FIXTURE_FILE = "./result/estate_condition.json"
 ESTATE_IMAGE_ORIGIN_DIR = "./origin/estate"
@@ -165,7 +166,7 @@ if __name__ == '__main__':
     with open(DESCRIPTION_LINES_FILE, mode='r', encoding='utf-8') as description_lines:
         desc_lines = description_lines.readlines()
 
-    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile:
+    with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile, open(OUTPUT_UPDATE_SQL_FILE, mode='w', encoding='utf-8') as update_sqlfile:
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -189,7 +190,10 @@ if __name__ == '__main__':
         sqlfile.write(sqlCommand)
         txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                  for estate in ESTATES_FOR_VERIFY]) + "\n")
-
+        update_sqlfile.write("\n".join([
+            "UPDATE isuumo.estate SET view_count = {} WHERE id = {};".format(estate['view_count'], estate['id'])
+            for estate in ESTATES_FOR_VERIFY
+        ]))
         estate_id += len(ESTATES_FOR_VERIFY)
 
         for _ in range(RECORD_COUNT//BULK_INSERT_COUNT):
@@ -200,6 +204,10 @@ if __name__ == '__main__':
             sqlfile.write(sqlCommand)
             txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                      for estate in bulk_list]) + "\n")
+            update_sqlfile.write("\n".join([
+                "UPDATE isuumo.estate SET view_count = {} WHERE id = {};".format(estate['view_count'], estate['id'])
+                for estate in ESTATES_FOR_VERIFY
+            ]))
 
     with open(OUTPUT_FIXTURE_FILE, mode='w', encoding='utf-8') as fixture_file:
         fixture_file.write(json.dumps({

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -167,6 +167,7 @@ if __name__ == '__main__':
         desc_lines = description_lines.readlines()
 
     with open(OUTPUT_SQL_FILE, mode='w', encoding='utf-8') as sqlfile, open(OUTPUT_TXT_FILE, mode='w', encoding='utf-8') as txtfile, open(OUTPUT_UPDATE_SQL_FILE, mode='w', encoding='utf-8') as update_sqlfile:
+        update_sqlfile.write("START TRANSACTION;\n")
         if RECORD_COUNT % BULK_INSERT_COUNT != 0:
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
@@ -208,6 +209,7 @@ if __name__ == '__main__':
                 "UPDATE isuumo.estate SET view_count = {} WHERE id = {};".format(estate['view_count'], estate['id'])
                 for estate in ESTATES_FOR_VERIFY
             ]))
+        update_sqlfile.write("COMMIT;\n")
 
     with open(OUTPUT_FIXTURE_FILE, mode='w', encoding='utf-8') as fixture_file:
         fixture_file.write(json.dumps({


### PR DESCRIPTION
## 目的

- /initialize のI/O負荷を下げる

## 解決方法

- 毎回TABLEをDROPするのではなく, 変更される箇所のUPDATEのみを行うように修正


## 動作確認

- [ ] (動作確認の方法、確認ができたらチェックボックスを埋める)

