### PR TITLE
[bench] エラーが発生した回数を出力に含める

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -19,11 +19,16 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/scenario"
 )
 
+type Message struct {
+	Text  string `json:"text"`
+	Count int    `json:"count"`
+}
+
 type Output struct {
-	Pass     bool     `json:"pass"`
-	Score    int      `json:"score"`
-	Messages []string `json:"messages"`
-	Language string   `json:"language"`
+	Pass     bool      `json:"pass"`
+	Score    int       `json:"score"`
+	Messages []Message `json:"messages"`
+	Language string    `json:"language"`
 }
 
 type Config struct {
@@ -73,7 +78,7 @@ func main() {
 		output := Output{
 			Pass:     false,
 			Score:    0,
-			Messages: eMsgs,
+			Messages: uniqMsgs(eMsgs),
 			Language: "",
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
@@ -91,7 +96,7 @@ func main() {
 		output := Output{
 			Pass:     false,
 			Score:    0,
-			Messages: eMsgs,
+			Messages: uniqMsgs(eMsgs),
 			Language: initRes.Language,
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
@@ -172,17 +177,28 @@ func main() {
 	json.NewEncoder(os.Stdout).Encode(output)
 }
 
-func uniqMsgs(allMsgs []string) []string {
-	sort.Strings(allMsgs)
-	msgs := make([]string, 0, len(allMsgs))
+func uniqMsgs(allMsgs []string) []Message {
+	if len(allMsgs) == 0 {
+		return []Message{}
+	}
 
-	tmp := ""
+	sort.Strings(allMsgs)
+	msgs := make([]Message, 0, len(allMsgs))
+
+	preMsg := allMsgs[0]
+	cnt := 0
 
 	// 適当にuniqする
-	for _, m := range allMsgs {
-		if tmp != m {
-			tmp = m
-			msgs = append(msgs, m)
+	for _, msg := range allMsgs {
+		if preMsg != msg {
+			msgs = append(msgs, Message{
+				Text:  preMsg,
+				Count: cnt,
+			})
+			preMsg = msg
+			cnt = 1
+		} else {
+			cnt++
 		}
 	}
 

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -201,6 +201,10 @@ func uniqMsgs(allMsgs []string) []Message {
 			cnt++
 		}
 	}
+	msgs = append(msgs, Message{
+		Text:  preMsg,
+		Count: cnt,
+	})
 
 	return msgs
 }

--- a/bench/cmd/bench/bench_test.go
+++ b/bench/cmd/bench/bench_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_uniqMsgs(t *testing.T) {
+	type args struct {
+		allMsgs []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Message
+	}{
+		{
+			args: args{
+				allMsgs: []string{"A", "B", "B"},
+			},
+			want: []Message{
+				{Text: "A", Count: 1},
+				{Text: "B", Count: 2},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := uniqMsgs(tt.args.allMsgs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("uniqMsgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 目的

- エラーメッセージをユニークにするのはいいが、何回発生したなどの情報が抜け落ちるのが残念だという指摘をいただいた


## 解決方法

- 最終出力にエラーメッセージと、それが発生した回数を記述するように変更


## 動作確認

- [x] 最終出力にエラーメッセージと、それが発生した回数が含まれていることを確認

```json
{
   "pass":true,
   "score":399,
   "messages":[
      {
         "text":"GET /api/chair/:id: リクエストに失敗しました（タイムアウトしました）",
         "count":8
      },
      {
         "text":"GET /api/chair/search: リクエストに失敗しました（タイムアウトしました）",
         "count":9
      },
      {
         "text":"GET /api/estate/:id: リクエストに失敗しました（タイムアウトしました）",
         "count":17
      },
      {
         "text":"GET /api/estate/search: リクエストに失敗しました（タイムアウトしました）",
         "count":9
      },
      {
         "text":"GET /api/popular_chair: リクエストに失敗しました（タイムアウトしました）",
         "count":1
      },
      {
         "text":"GET /api/popular_estate: リクエストに失敗しました（タイムアウトしました）",
         "count":4
      }
   ],
   "language":"go"
}
```


## 参考文献 (Optional)

- なし
