### PR TITLE
[bench] レベルによるシナリオの負荷バランスを調整可能に

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -3,26 +3,50 @@ package parameter
 import "time"
 
 const (
-	NumOfInitialEstateSearchWorker        = 1
-	NumOfInitialChairSearchWorker         = 1
-	NumOfInitialEstateNazotteSearchWorker = 1
-	NumOfInitialBotWorker                 = 1
-	NumOfCheckChairSearchPaging           = 3
-	NumOfCheckEstateSearchPaging          = 3
-	PerPageOfChairSearch                  = 30
-	PerPageOfEstateSearch                 = 30
-	MaxLengthOfNazotteResponse            = 50
-	NeighborhoodRadiusOfNazotte           = 1e-6
-	SleepTimeOnFailScenario               = 1500 * time.Millisecond
-	SleepSwingOnFailScenario              = 500 // * time.Millisecond
-	SleepTimeOnUserAway                   = 500 * time.Millisecond
-	SleepSwingOnUserAway                  = 100 // * time.Millisecond
-	SleepTimeOnBotInterval                = 500 * time.Millisecond
-	SleepSwingOnBotInterval               = 100 // * time.Millisecond
-	IntervalForCheckWorkers               = 5 * time.Second
-	ThresholdTimeOfAbandonmentPage        = 1000 * time.Millisecond
-	DefaultAPITimeout                     = 2000 * time.Millisecond
-	InitializeTimeout                     = 30 * time.Second
-	VerifyTimeout                         = 10 * time.Second
-	LoadTimeout                           = 60 * time.Second
+	NumOfCheckChairSearchPaging    = 3
+	NumOfCheckEstateSearchPaging   = 3
+	PerPageOfChairSearch           = 30
+	PerPageOfEstateSearch          = 30
+	MaxLengthOfNazotteResponse     = 50
+	NeighborhoodRadiusOfNazotte    = 1e-6
+	SleepTimeOnFailScenario        = 1500 * time.Millisecond
+	SleepSwingOnFailScenario       = 500 // * time.Millisecond
+	SleepTimeOnUserAway            = 500 * time.Millisecond
+	SleepSwingOnUserAway           = 100 // * time.Millisecond
+	SleepTimeOnBotInterval         = 500 * time.Millisecond
+	SleepSwingOnBotInterval        = 100 // * time.Millisecond
+	IntervalForCheckWorkers        = 5 * time.Second
+	ThresholdTimeOfAbandonmentPage = 1000 * time.Millisecond
+	DefaultAPITimeout              = 2000 * time.Millisecond
+	InitializeTimeout              = 30 * time.Second
+	VerifyTimeout                  = 10 * time.Second
+	LoadTimeout                    = 60 * time.Second
 )
+
+// IncListOfWorkers 前のレベルとのWorkerの個数の差分を保持するList
+// [level][0]: inc of EstateSearchWorker
+// [level][1]: inc of ChairSearchWorker
+// [level][2]: inc of EstateNazotteSearchWorker
+// [level][3]: inc of BotWorker
+var IncListOfWorkers = [][4]int{
+	{1, 1, 1, 1}, // level 00
+	{1, 1, 1, 1}, // level 01
+	{1, 1, 1, 1}, // level 02
+	{1, 1, 1, 1}, // level 03
+	{1, 1, 1, 1}, // level 04
+	{1, 1, 1, 1}, // level 05
+	{1, 1, 1, 1}, // level 06
+	{1, 1, 1, 1}, // level 07
+	{1, 1, 1, 1}, // level 08
+	{1, 1, 1, 1}, // level 09
+	{1, 1, 1, 1}, // level 10
+	{1, 1, 1, 1}, // level 11
+	{1, 1, 1, 1}, // level 12
+	{1, 1, 1, 1}, // level 13
+	{1, 1, 1, 1}, // level 14
+	{1, 1, 1, 1}, // level 15
+	{1, 1, 1, 1}, // level 16
+	{1, 1, 1, 1}, // level 17
+	{1, 1, 1, 1}, // level 18
+	{1, 1, 1, 1}, // level 19
+}

--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -23,30 +23,133 @@ const (
 	LoadTimeout                    = 60 * time.Second
 )
 
+type incWorkers struct {
+	ChairSearchWorker         int
+	EstateSearchWorker        int
+	EstateNazotteSearchWorker int
+	BotWorker                 int
+}
+
 // IncListOfWorkers 前のレベルとのWorkerの個数の差分を保持するList
-// [level][0]: inc of EstateSearchWorker
-// [level][1]: inc of ChairSearchWorker
-// [level][2]: inc of EstateNazotteSearchWorker
-// [level][3]: inc of BotWorker
-var IncListOfWorkers = [][4]int{
-	{1, 1, 1, 1}, // level 00
-	{1, 1, 1, 1}, // level 01
-	{1, 1, 1, 1}, // level 02
-	{1, 1, 1, 1}, // level 03
-	{1, 1, 1, 1}, // level 04
-	{1, 1, 1, 1}, // level 05
-	{1, 1, 1, 1}, // level 06
-	{1, 1, 1, 1}, // level 07
-	{1, 1, 1, 1}, // level 08
-	{1, 1, 1, 1}, // level 09
-	{1, 1, 1, 1}, // level 10
-	{1, 1, 1, 1}, // level 11
-	{1, 1, 1, 1}, // level 12
-	{1, 1, 1, 1}, // level 13
-	{1, 1, 1, 1}, // level 14
-	{1, 1, 1, 1}, // level 15
-	{1, 1, 1, 1}, // level 16
-	{1, 1, 1, 1}, // level 17
-	{1, 1, 1, 1}, // level 18
-	{1, 1, 1, 1}, // level 19
+var ListOfIncWorkers = []incWorkers{
+	{ // level 00
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 01
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 02
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 03
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 04
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 05
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 06
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 07
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 08
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 09
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 10
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 11
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 12
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 13
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 14
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 15
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 16
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 17
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 18
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
+	{ // level 19
+		ChairSearchWorker:         1,
+		EstateSearchWorker:        1,
+		EstateNazotteSearchWorker: 1,
+		BotWorker:                 1,
+	},
 }

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -157,17 +157,17 @@ func checkWorkers(ctx context.Context) {
 				time.Since(net) > parameter.IntervalForCheckWorkers {
 				log.Println("負荷レベルが上昇しました。")
 				level := atomic.AddInt64(&loadLevel, 1)
-				incList := parameter.IncListOfWorkers[level]
-				for i := 0; i < incList[0]; i++ {
+				incWorkers := parameter.ListOfIncWorkers[level]
+				for i := 0; i < incWorkers.ChairSearchWorker; i++ {
 					go runChairSearchWorker(ctx)
 				}
-				for i := 0; i < incList[1]; i++ {
+				for i := 0; i < incWorkers.EstateSearchWorker; i++ {
 					go runEstateSearchWorker(ctx)
 				}
-				for i := 0; i < incList[2]; i++ {
+				for i := 0; i < incWorkers.EstateNazotteSearchWorker; i++ {
 					go runEstateNazotteSearchWorker(ctx)
 				}
-				for i := 0; i < incList[3]; i++ {
+				for i := 0; i < incWorkers.BotWorker; i++ {
 					go runBotWorker(ctx)
 				}
 			} else {
@@ -182,25 +182,25 @@ func checkWorkers(ctx context.Context) {
 
 func Load(ctx context.Context) {
 	level := GetLoadLevel()
-	incList := parameter.IncListOfWorkers[level]
+	incWorkers := parameter.ListOfIncWorkers[level]
 
 	// 物件検索をして、資料請求をするシナリオ
-	for i := 0; i < incList[0]; i++ {
+	for i := 0; i < incWorkers.ChairSearchWorker; i++ {
 		go runChairSearchWorker(ctx)
 	}
 
 	// イス検索から物件ページに行き、資料請求をするまでのシナリオ
-	for i := 0; i < incList[1]; i++ {
+	for i := 0; i < incWorkers.EstateSearchWorker; i++ {
 		go runEstateSearchWorker(ctx)
 	}
 
 	// なぞって検索をするシナリオ
-	for i := 0; i < incList[2]; i++ {
+	for i := 0; i < incWorkers.EstateNazotteSearchWorker; i++ {
 		go runEstateNazotteSearchWorker(ctx)
 	}
 
 	// ボットによる検索シナリオ
-	for i := 0; i < incList[3]; i++ {
+	for i := 0; i < incWorkers.BotWorker; i++ {
 		go runBotWorker(ctx)
 	}
 

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -21,10 +21,6 @@ func GetLoadLevel() int64 {
 	return atomic.LoadInt64(&loadLevel)
 }
 
-func IncrementLoadLevel() {
-	atomic.AddInt64(&loadLevel, 1)
-}
-
 func runEstateSearchWorker(ctx context.Context) {
 	u, _ := uuid.NewRandom()
 	c := client.NewClient(fmt.Sprintf("isucon-user-%v", u.String()), false)
@@ -160,10 +156,20 @@ func checkWorkers(ctx context.Context) {
 				time.Since(eet) > parameter.IntervalForCheckWorkers &&
 				time.Since(net) > parameter.IntervalForCheckWorkers {
 				log.Println("負荷レベルが上昇しました。")
-				go runChairSearchWorker(ctx)
-				go runEstateSearchWorker(ctx)
-				go runEstateNazotteSearchWorker(ctx)
-				IncrementLoadLevel()
+				level := atomic.AddInt64(&loadLevel, 1)
+				incList := parameter.IncListOfWorkers[level]
+				for i := 0; i < incList[0]; i++ {
+					go runChairSearchWorker(ctx)
+				}
+				for i := 0; i < incList[1]; i++ {
+					go runEstateSearchWorker(ctx)
+				}
+				for i := 0; i < incList[2]; i++ {
+					go runEstateNazotteSearchWorker(ctx)
+				}
+				for i := 0; i < incList[3]; i++ {
+					go runBotWorker(ctx)
+				}
 			} else {
 				log.Println("シナリオ内でエラーが発生したため負荷レベルを上げられませんでした。")
 			}
@@ -175,23 +181,26 @@ func checkWorkers(ctx context.Context) {
 }
 
 func Load(ctx context.Context) {
-	// 物件検索をして、資料請求をするシナリオ
-	for i := 0; i < parameter.NumOfInitialEstateSearchWorker; i++ {
-		go runEstateSearchWorker(ctx)
-	}
+	level := GetLoadLevel()
+	incList := parameter.IncListOfWorkers[level]
 
-	// イス検索から物件ページに行き、資料請求をするまでのシナリオ
-	for i := 0; i < parameter.NumOfInitialChairSearchWorker; i++ {
+	// 物件検索をして、資料請求をするシナリオ
+	for i := 0; i < incList[0]; i++ {
 		go runChairSearchWorker(ctx)
 	}
 
+	// イス検索から物件ページに行き、資料請求をするまでのシナリオ
+	for i := 0; i < incList[1]; i++ {
+		go runEstateSearchWorker(ctx)
+	}
+
 	// なぞって検索をするシナリオ
-	for i := 0; i < parameter.NumOfInitialEstateNazotteSearchWorker; i++ {
+	for i := 0; i < incList[2]; i++ {
 		go runEstateNazotteSearchWorker(ctx)
 	}
 
 	// ボットによる検索シナリオ
-	for i := 0; i < parameter.NumOfInitialBotWorker; i++ {
+	for i := 0; i < incList[3]; i++ {
 		go runBotWorker(ctx)
 	}
 


### PR DESCRIPTION
## 目的

- 難易度調整の段階で、簡単な (解いてほしい) ボトルネックほど最初に出現するように調整するための機構が欲しくなってきた


## 解決方法

- 負荷上昇によって増える worker の数をシナリオ毎に調整できるように変更した


## 動作確認

- [x] ベンチマークが正常に終了することを確認


## 参考文献 (Optional)

- なし
