### PR TITLE
[webapp] view_countをpopularityにrenameし、詳細閲覧によって増加しないように変更

### DIFF
--- a/agreed/api/estate.js
+++ b/agreed/api/estate.js
@@ -279,7 +279,7 @@ module.exports = [
             doorWidth: 120,
             rent: 2500000,
             features: '駅直結,バストイレ別',
-            view_count: 10000
+            popularity: 10000
           },
           {
             id: 5,
@@ -372,7 +372,7 @@ module.exports = [
             doorWidth: 120,
             rent: 2500000,
             features: '駅直結,バストイレ別',
-            view_count: 10000
+            popularity: 10000
           },
           {
             id: 5,

--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -123,9 +123,9 @@ func GetChairFromID(id int64) (*Chair, error) {
 	return nil, errors.New("requested chair not found")
 }
 
-func IncrementChairViewCount(id int64) {
+func IncrementChairPopularity(id int64) {
 	if ExistsChairInMap(id) {
-		chairMap[id].IncrementViewCount()
+		chairMap[id].IncrementPopularity()
 	}
 }
 
@@ -153,8 +153,8 @@ func GetEstateFromID(id int64) (*Estate, error) {
 	return nil, errors.New("requested estate not found")
 }
 
-func IncrementEstateViewCount(id int64) {
+func IncrementEstatePopularity(id int64) {
 	if ExistsEstateInMap(id) {
-		estateMap[id].IncrementViewCount()
+		estateMap[id].IncrementPopularity()
 	}
 }

--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -123,12 +123,6 @@ func GetChairFromID(id int64) (*Chair, error) {
 	return nil, errors.New("requested chair not found")
 }
 
-func IncrementChairPopularity(id int64) {
-	if ExistsChairInMap(id) {
-		chairMap[id].IncrementPopularity()
-	}
-}
-
 func DecrementChairStock(id int64) {
 	if ExistsChairInMap(id) {
 		chairMap[id].DecrementStock()
@@ -151,10 +145,4 @@ func GetEstateFromID(id int64) (*Estate, error) {
 		return e, nil
 	}
 	return nil, errors.New("requested estate not found")
-}
-
-func IncrementEstatePopularity(id int64) {
-	if ExistsEstateInMap(id) {
-		estateMap[id].IncrementPopularity()
-	}
 }

--- a/bench/asset/chair.go
+++ b/bench/asset/chair.go
@@ -17,7 +17,7 @@ type JSONChair struct {
 	Depth       int64  `json:"depth"`
 	Color       string `json:"color"`
 	Features    string `json:"features"`
-	ViewCount   int64  `json:"view_count"`
+	Popularity   int64  `json:"popularity"`
 	Kind        string `json:"kind"`
 	Stock       int64  `json:"stock"`
 }
@@ -35,7 +35,7 @@ type Chair struct {
 	Features    string
 	Kind        string
 
-	viewCount   int64
+	popularity   int64
 	stock       int64
 	soldOutTime atomic.Value
 }
@@ -53,7 +53,7 @@ func (c Chair) MarshalJSON() ([]byte, error) {
 		Depth:       c.Depth,
 		Color:       c.Color,
 		Features:    c.Features,
-		ViewCount:   c.viewCount,
+		Popularity:   c.popularity,
 		Kind:        c.Kind,
 		Stock:       c.stock,
 	}
@@ -79,7 +79,7 @@ func (c *Chair) UnmarshalJSON(data []byte) error {
 	c.Depth = jc.Depth
 	c.Color = jc.Color
 	c.Features = jc.Features
-	c.viewCount = jc.ViewCount
+	c.popularity = jc.Popularity
 	c.Kind = jc.Kind
 	c.stock = jc.Stock
 	c.soldOutTime = atomic.Value{}
@@ -101,16 +101,16 @@ func (c1 *Chair) Equal(c2 *Chair) bool {
 		c1.Kind == c2.Kind
 }
 
-func (c *Chair) GetViewCount() int64 {
-	return atomic.LoadInt64(&(c.viewCount))
+func (c *Chair) GetPopularity() int64 {
+	return atomic.LoadInt64(&(c.popularity))
 }
 
 func (c *Chair) GetStock() int64 {
 	return atomic.LoadInt64(&(c.stock))
 }
 
-func (c *Chair) IncrementViewCount() {
-	atomic.AddInt64(&(c.viewCount), 1)
+func (c *Chair) IncrementPopularity() {
+	atomic.AddInt64(&(c.popularity), 1)
 }
 
 func (c *Chair) DecrementStock() {

--- a/bench/asset/chair.go
+++ b/bench/asset/chair.go
@@ -17,7 +17,7 @@ type JSONChair struct {
 	Depth       int64  `json:"depth"`
 	Color       string `json:"color"`
 	Features    string `json:"features"`
-	Popularity   int64  `json:"popularity"`
+	Popularity  int64  `json:"popularity"`
 	Kind        string `json:"kind"`
 	Stock       int64  `json:"stock"`
 }
@@ -35,7 +35,7 @@ type Chair struct {
 	Features    string
 	Kind        string
 
-	popularity   int64
+	popularity  int64
 	stock       int64
 	soldOutTime atomic.Value
 }
@@ -53,7 +53,7 @@ func (c Chair) MarshalJSON() ([]byte, error) {
 		Depth:       c.Depth,
 		Color:       c.Color,
 		Features:    c.Features,
-		Popularity:   c.popularity,
+		Popularity:  c.popularity,
 		Kind:        c.Kind,
 		Stock:       c.stock,
 	}

--- a/bench/asset/chair.go
+++ b/bench/asset/chair.go
@@ -102,15 +102,11 @@ func (c1 *Chair) Equal(c2 *Chair) bool {
 }
 
 func (c *Chair) GetPopularity() int64 {
-	return atomic.LoadInt64(&(c.popularity))
+	return c.popularity
 }
 
 func (c *Chair) GetStock() int64 {
 	return atomic.LoadInt64(&(c.stock))
-}
-
-func (c *Chair) IncrementPopularity() {
-	atomic.AddInt64(&(c.popularity), 1)
 }
 
 func (c *Chair) DecrementStock() {

--- a/bench/asset/chair_test.go
+++ b/bench/asset/chair_test.go
@@ -33,13 +33,13 @@ func Test_ParallelStockDecrement(t *testing.T) {
 	}
 }
 
-func Test_ParallelViewCountIncrement(t *testing.T) {
+func Test_ParallelPopularityIncrement(t *testing.T) {
 	type Incrementable interface {
-		GetViewCount() int64
-		IncrementViewCount()
+		GetPopularity() int64
+		IncrementPopularity()
 	}
 
-	initialViewCount := int64(100)
+	initialPopularity := int64(100)
 
 	testAsset := []struct {
 		TestName string
@@ -48,13 +48,13 @@ func Test_ParallelViewCountIncrement(t *testing.T) {
 		{
 			TestName: "Test Chair",
 			Asset: &Chair{
-				viewCount: initialViewCount,
+				popularity: initialPopularity,
 			},
 		},
 		{
 			TestName: "Test Estate",
 			Asset: &Estate{
-				viewCount: initialViewCount,
+				popularity: initialPopularity,
 			},
 		},
 	}
@@ -69,14 +69,14 @@ func Test_ParallelViewCountIncrement(t *testing.T) {
 					defer wg.Done()
 					<-start
 					for j := 0; j < 100; j++ {
-						tc.Asset.IncrementViewCount()
+						tc.Asset.IncrementPopularity()
 					}
 				}()
 			}
 			close(start)
 			wg.Wait()
-			got := tc.Asset.GetViewCount()
-			expected := initialViewCount + 100*100
+			got := tc.Asset.GetPopularity()
+			expected := initialPopularity + 100*100
 			if got != expected {
 				t.Errorf("unexpected stocks. expected: %v, but got: %v", expected, got)
 			}
@@ -98,7 +98,7 @@ func TestChair_MarshalJSON(t *testing.T) {
 		Features:    "features",
 		Kind:        "kind",
 		stock:       6,
-		viewCount:   7,
+		popularity:   7,
 	}
 	b, err := json.Marshal(chair)
 	if err != nil {

--- a/bench/asset/chair_test.go
+++ b/bench/asset/chair_test.go
@@ -47,7 +47,7 @@ func TestChair_MarshalJSON(t *testing.T) {
 		Features:    "features",
 		Kind:        "kind",
 		stock:       6,
-		popularity:   7,
+		popularity:  7,
 	}
 	b, err := json.Marshal(chair)
 	if err != nil {

--- a/bench/asset/chair_test.go
+++ b/bench/asset/chair_test.go
@@ -33,57 +33,6 @@ func Test_ParallelStockDecrement(t *testing.T) {
 	}
 }
 
-func Test_ParallelPopularityIncrement(t *testing.T) {
-	type Incrementable interface {
-		GetPopularity() int64
-		IncrementPopularity()
-	}
-
-	initialPopularity := int64(100)
-
-	testAsset := []struct {
-		TestName string
-		Asset    Incrementable
-	}{
-		{
-			TestName: "Test Chair",
-			Asset: &Chair{
-				popularity: initialPopularity,
-			},
-		},
-		{
-			TestName: "Test Estate",
-			Asset: &Estate{
-				popularity: initialPopularity,
-			},
-		},
-	}
-
-	for _, tc := range testAsset {
-		t.Run(tc.TestName, func(t *testing.T) {
-			var wg sync.WaitGroup
-			start := make(chan struct{})
-			for i := 0; i < 100; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					<-start
-					for j := 0; j < 100; j++ {
-						tc.Asset.IncrementPopularity()
-					}
-				}()
-			}
-			close(start)
-			wg.Wait()
-			got := tc.Asset.GetPopularity()
-			expected := initialPopularity + 100*100
-			if got != expected {
-				t.Errorf("unexpected stocks. expected: %v, but got: %v", expected, got)
-			}
-		})
-	}
-}
-
 func TestChair_MarshalJSON(t *testing.T) {
 	chair := Chair{
 		ID:          1,

--- a/bench/asset/estate.go
+++ b/bench/asset/estate.go
@@ -16,7 +16,7 @@ type JSONEstate struct {
 	Longitude   float64 `json:"longitude"`
 	DoorHeight  int64   `json:"doorHeight"`
 	DoorWidth   int64   `json:"doorWidth"`
-	ViewCount   int64   `json:"viewCount"`
+	Popularity   int64   `json:"popularity"`
 	Rent        int64   `json:"rent"`
 	Features    string  `json:"features"`
 }
@@ -34,7 +34,7 @@ type Estate struct {
 	Rent        int64
 	Features    string
 
-	viewCount int64
+	popularity int64
 }
 
 func (e Estate) MarshalJSON() ([]byte, error) {
@@ -51,7 +51,7 @@ func (e Estate) MarshalJSON() ([]byte, error) {
 		DoorHeight:  e.DoorHeight,
 		DoorWidth:   e.DoorWidth,
 		Features:    e.Features,
-		ViewCount:   e.viewCount,
+		Popularity:   e.popularity,
 	}
 
 	return json.Marshal(m)
@@ -77,7 +77,7 @@ func (e *Estate) UnmarshalJSON(data []byte) error {
 	e.Latitude = je.Latitude
 	e.Longitude = je.Longitude
 	e.Features = je.Features
-	e.viewCount = je.ViewCount
+	e.popularity = je.Popularity
 
 	return nil
 }
@@ -96,10 +96,10 @@ func (e1 *Estate) Equal(e2 *Estate) bool {
 		e1.Features == e2.Features
 }
 
-func (e *Estate) GetViewCount() int64 {
-	return atomic.LoadInt64(&(e.viewCount))
+func (e *Estate) GetPopularity() int64 {
+	return atomic.LoadInt64(&(e.popularity))
 }
 
-func (e *Estate) IncrementViewCount() {
-	atomic.AddInt64(&(e.viewCount), 1)
+func (e *Estate) IncrementPopularity() {
+	atomic.AddInt64(&(e.popularity), 1)
 }

--- a/bench/asset/estate.go
+++ b/bench/asset/estate.go
@@ -3,7 +3,6 @@ package asset
 import (
 	"encoding/json"
 	"fmt"
-	"sync/atomic"
 )
 
 type JSONEstate struct {
@@ -16,7 +15,7 @@ type JSONEstate struct {
 	Longitude   float64 `json:"longitude"`
 	DoorHeight  int64   `json:"doorHeight"`
 	DoorWidth   int64   `json:"doorWidth"`
-	Popularity   int64   `json:"popularity"`
+	Popularity  int64   `json:"popularity"`
 	Rent        int64   `json:"rent"`
 	Features    string  `json:"features"`
 }
@@ -51,7 +50,7 @@ func (e Estate) MarshalJSON() ([]byte, error) {
 		DoorHeight:  e.DoorHeight,
 		DoorWidth:   e.DoorWidth,
 		Features:    e.Features,
-		Popularity:   e.popularity,
+		Popularity:  e.popularity,
 	}
 
 	return json.Marshal(m)
@@ -97,9 +96,5 @@ func (e1 *Estate) Equal(e2 *Estate) bool {
 }
 
 func (e *Estate) GetPopularity() int64 {
-	return atomic.LoadInt64(&(e.popularity))
-}
-
-func (e *Estate) IncrementPopularity() {
-	atomic.AddInt64(&(e.popularity), 1)
+	return e.popularity
 }

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -125,8 +125,6 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/:id: JSONデコードに失敗しました"))
 	}
 
-	asset.IncrementChairPopularity(chair.ID)
-
 	return &chair, nil
 }
 
@@ -377,8 +375,6 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 		}
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/:id: JSONデコードに失敗しました"))
 	}
-
-	asset.IncrementEstatePopularity(estate.ID)
 
 	return &estate, nil
 }

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -125,7 +125,7 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 		return nil, failure.Wrap(err, failure.Message("GET /api/chair/:id: JSONデコードに失敗しました"))
 	}
 
-	asset.IncrementChairViewCount(chair.ID)
+	asset.IncrementChairPopularity(chair.ID)
 
 	return &chair, nil
 }
@@ -378,7 +378,7 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 		return nil, failure.Wrap(err, failure.Message("GET /api/estate/:id: JSONデコードに失敗しました"))
 	}
 
-	asset.IncrementEstateViewCount(estate.ID)
+	asset.IncrementEstatePopularity(estate.ID)
 
 	return &estate, nil
 }

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -104,7 +104,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return nil
 	}
 
-	if !isChairsOrderedByViewCount(cr.Chairs, t) {
+	if !isChairsOrderedByPopularity(cr.Chairs, t) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -132,7 +132,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isChairsOrderedByViewCount(cr.Chairs, t) {
+			if !isChairsOrderedByPopularity(cr.Chairs, t) {
 				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
@@ -169,7 +169,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isEstatesOrderedByViewCount(er.Estates) {
+	if !isEstatesOrderedByPopularity(er.Estates) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: おすすめ結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)

--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -22,7 +22,7 @@ func isEstatesOrderedByPopularity(e []asset.Estate) bool {
 			return false
 		}
 		p := e.GetPopularity()
-		if i > 0 && popularity >= p {
+		if i > 0 && popularity < p {
 			return false
 		}
 		popularity = p
@@ -64,7 +64,7 @@ func isChairsOrderedByPopularity(c []asset.Chair, t time.Time) bool {
 
 		p := _chair.GetPopularity()
 
-		if i > 0 && popularity >= p {
+		if i > 0 && popularity < p {
 			return false
 		}
 		popularity = p

--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -14,18 +14,18 @@ func isEstateEqualToAsset(e *asset.Estate) bool {
 	return estate.Equal(e)
 }
 
-func isEstatesOrderedByViewCount(e []asset.Estate) bool {
-	var viewCount int64 = -1
+func isEstatesOrderedByPopularity(e []asset.Estate) bool {
+	var popularity int64 = -1
 	for i, estate := range e {
 		e, err := asset.GetEstateFromID(estate.ID)
 		if err != nil {
 			return false
 		}
-		vc := e.GetViewCount()
-		if i > 0 && viewCount-vc < -3 {
+		vc := e.GetPopularity()
+		if i > 0 && popularity-vc < -3 {
 			return false
 		}
-		viewCount = vc
+		popularity = vc
 	}
 	return true
 }
@@ -50,8 +50,8 @@ func isChairSoldOutAt(c *asset.Chair, t time.Time) bool {
 	return t.After(*soldOutTime)
 }
 
-func isChairsOrderedByViewCount(c []asset.Chair, t time.Time) bool {
-	var viewCount int64 = -1
+func isChairsOrderedByPopularity(c []asset.Chair, t time.Time) bool {
+	var popularity int64 = -1
 	for i, chair := range c {
 		_chair, err := asset.GetChairFromID(chair.ID)
 		if err != nil {
@@ -62,12 +62,12 @@ func isChairsOrderedByViewCount(c []asset.Chair, t time.Time) bool {
 			return false
 		}
 
-		vc := _chair.GetViewCount()
+		vc := _chair.GetPopularity()
 
-		if i > 0 && viewCount-vc < -3 {
+		if i > 0 && popularity-vc < -3 {
 			return false
 		}
-		viewCount = vc
+		popularity = vc
 	}
 	return true
 }

--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -21,11 +21,11 @@ func isEstatesOrderedByPopularity(e []asset.Estate) bool {
 		if err != nil {
 			return false
 		}
-		vc := e.GetPopularity()
-		if i > 0 && popularity-vc < -3 {
+		p := e.GetPopularity()
+		if i > 0 && popularity >= p {
 			return false
 		}
-		popularity = vc
+		popularity = p
 	}
 	return true
 }
@@ -62,12 +62,12 @@ func isChairsOrderedByPopularity(c []asset.Chair, t time.Time) bool {
 			return false
 		}
 
-		vc := _chair.GetPopularity()
+		p := _chair.GetPopularity()
 
-		if i > 0 && popularity-vc < -3 {
+		if i > 0 && popularity >= p {
 			return false
 		}
-		popularity = vc
+		popularity = p
 	}
 	return true
 }

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -99,7 +99,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return nil
 	}
 
-	if !isEstatesOrderedByViewCount(er.Estates) {
+	if !isEstatesOrderedByPopularity(er.Estates) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -126,7 +126,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isEstatesOrderedByViewCount(er.Estates) {
+			if !isEstatesOrderedByPopularity(er.Estates) {
 				err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -47,7 +47,7 @@ func verifyChairStock(ctx context.Context, c *client.Client, chairFeatureForVeri
 	return nil
 }
 
-func verifyChairViewCount(ctx context.Context, c *client.Client, chairFeatureForVerify string) error {
+func verifyChairPopularity(ctx context.Context, c *client.Client, chairFeatureForVerify string) error {
 	for i := 0; i < 2; i++ {
 		_, err := c.GetChairDetailFromID(ctx, "2")
 		if err != nil {
@@ -79,7 +79,7 @@ func verifyChairViewCount(ctx context.Context, c *client.Client, chairFeatureFor
 	return nil
 }
 
-func verifyEstateViewCount(ctx context.Context, c *client.Client, estateFeatureForVerify string) error {
+func verifyEstatePopularity(ctx context.Context, c *client.Client, estateFeatureForVerify string) error {
 	for i := 0; i < 2; i++ {
 		_, err := c.GetEstateDetailFromID(ctx, "1")
 		if err != nil {
@@ -132,7 +132,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string
 
 	wg.Add(1)
 	go func() {
-		err := verifyChairViewCount(ctx, c, *chairFeatureForVerify)
+		err := verifyChairPopularity(ctx, c, *chairFeatureForVerify)
 		if err != nil {
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
 		}
@@ -141,7 +141,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string
 
 	wg.Add(1)
 	go func() {
-		err := verifyEstateViewCount(ctx, c, *estateFeatureForVerify)
+		err := verifyEstatePopularity(ctx, c, *estateFeatureForVerify)
 		if err != nil {
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
 		}

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -2,7 +2,6 @@ package scenario
 
 import (
 	"context"
-	"net/url"
 	"sync"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
@@ -47,74 +46,8 @@ func verifyChairStock(ctx context.Context, c *client.Client, chairFeatureForVeri
 	return nil
 }
 
-func verifyChairPopularity(ctx context.Context, c *client.Client, chairFeatureForVerify string) error {
-	for i := 0; i < 2; i++ {
-		_, err := c.GetChairDetailFromID(ctx, "2")
-		if err != nil {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return ctxErr
-			}
-			return failure.Translate(err, fails.ErrApplication)
-		}
-	}
-
-	q := url.Values{}
-	q.Add("features", chairFeatureForVerify)
-	q.Add("page", "0")
-	q.Add("perPage", "2")
-
-	chairs, err := c.SearchChairsWithQuery(ctx, q)
-
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		return failure.Translate(err, fails.ErrApplication)
-	}
-
-	if chairs.Chairs[0].ID != 2 || chairs.Chairs[1].ID != 3 {
-		return failure.New(fails.ErrApplication, failure.Message("イスの閲覧数が不正です"))
-	}
-
-	return nil
-}
-
-func verifyEstatePopularity(ctx context.Context, c *client.Client, estateFeatureForVerify string) error {
-	for i := 0; i < 2; i++ {
-		_, err := c.GetEstateDetailFromID(ctx, "1")
-		if err != nil {
-			return failure.Translate(err, fails.ErrApplication)
-		}
-	}
-
-	q := url.Values{}
-	q.Add("features", estateFeatureForVerify)
-	q.Add("page", "0")
-	q.Add("perPage", "2")
-
-	estates, err := c.SearchEstatesWithQuery(ctx, q)
-
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		return failure.Translate(err, fails.ErrApplication)
-	}
-
-	if estates.Estates[0].ID != 1 || estates.Estates[1].ID != 2 {
-		return failure.New(fails.ErrApplication, failure.Message("物件の閲覧数が不正です"))
-	}
-
-	return nil
-}
-
 func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string) {
 	chairFeatureForVerify, err := asset.GetChairFeatureForVerify()
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
-	}
-
-	estateFeatureForVerify, err := asset.GetEstateFeatureForVerify()
 	if err != nil {
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
 	}
@@ -124,24 +57,6 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string
 	wg.Add(1)
 	go func() {
 		err := verifyChairStock(ctx, c, *chairFeatureForVerify)
-		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
-		}
-		wg.Done()
-	}()
-
-	wg.Add(1)
-	go func() {
-		err := verifyChairPopularity(ctx, c, *chairFeatureForVerify)
-		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
-		}
-		wg.Done()
-	}()
-
-	wg.Add(1)
-	go func() {
-		err := verifyEstatePopularity(ctx, c, *estateFeatureForVerify)
 		if err != nil {
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
 		}

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -183,7 +183,7 @@ def dump_chair_to_json_str(chair):
         "width": chair["width"],
         "depth": chair["depth"],
         "color": chair["color"],
-        "view_count": chair["view_count"],
+        "popularity": chair["popularity"],
         "stock": chair["stock"],
         "description": chair["description"],
         "features": chair["features"],
@@ -208,7 +208,7 @@ def generate_chair_dummy_data(chair_id, wrap={}):
         "width": random.randint(CHAIR_MIN_CENTIMETER, CHAIR_MAX_CENTIMETER),
         "depth": random.randint(CHAIR_MIN_CENTIMETER, CHAIR_MAX_CENTIMETER),
         "color": fake.word(ext_word_list=CHAIR_COLOR_LIST),
-        "view_count": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
+        "popularity": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
         "stock": random.randint(1, 10),
         "description": random.choice(desc_lines).strip(),
         "features": ",".join(fake.words(nb=features_length, ext_word_list=CHAIR_FEATURE_LIST, unique=True)),
@@ -241,21 +241,21 @@ if __name__ == "__main__":
             generate_chair_dummy_data(1, {
                 "features": CHAIR_FEATURE_FOR_VERIFY,
                 "stock": 1,
-                "view_count": MIN_VIEW_COUNT
+                "popularity": MIN_VIEW_COUNT
             }),
             # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (2位 → 1位)
             generate_chair_dummy_data(2, {
                 "features": CHAIR_FEATURE_FOR_VERIFY,
-                "view_count": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
+                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
             }),
             # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (1位 → 2位)
             generate_chair_dummy_data(3, {
                 "features": CHAIR_FEATURE_FOR_VERIFY,
-                "view_count": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
+                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
             })
         ]
 
-        sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
+        sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, popularity, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['popularity']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
         sqlfile.write(sqlCommand)
         txtfile.write(
             "\n".join([dump_chair_to_json_str(chair) for chair in CHAIRS_FOR_VERIFY]) + "\n")
@@ -266,7 +266,7 @@ if __name__ == "__main__":
             bulk_list = [generate_chair_dummy_data(
                 chair_id + i) for i in range(BULK_INSERT_COUNT)]
             chair_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, view_count, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['view_count']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
+            sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, popularity, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['popularity']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", bulk_list))};"""
             sqlfile.write(sqlCommand)
 
             txtfile.write(

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -125,7 +125,7 @@ def dump_estate_to_json_str(estate):
         "rent": estate["rent"],
         "doorHeight": estate["door_height"],
         "doorWidth": estate["door_width"],
-        "viewCount": estate["view_count"],
+        "popularity": estate["popularity"],
         "description": estate["description"],
         "features": estate["features"]
     }, ensure_ascii=False)
@@ -146,7 +146,7 @@ def generate_estate_dummy_data(estate_id, wrap={}):
         "rent": random.randint(30000, 200000),
         "door_height": random.randint(DOOR_MIN_CENTIMETER, DOOR_MAX_CENTIMETER),
         "door_width": random.randint(DOOR_MIN_CENTIMETER, DOOR_MAX_CENTIMETER),
-        "view_count": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
+        "popularity": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
         "description": random.choice(desc_lines).strip(),
         "features": ','.join(fake.words(nb=feature_length, ext_word_list=ESTATE_FEATURE_LIST, unique=True))
     }
@@ -176,16 +176,16 @@ if __name__ == '__main__':
             # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (2位 → 1位)
             generate_estate_dummy_data(1, {
                 "features": ESTATE_FEATURE_FOR_VERIFY,
-                "view_count": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
+                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
             }),
             # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (1位 → 2位)
             generate_estate_dummy_data(2, {
                 "features": ESTATE_FEATURE_FOR_VERIFY,
-                "view_count": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
+                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
             })
         ]
 
-        sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", ESTATES_FOR_VERIFY))};"""
+        sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, popularity, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['popularity']}', '{estate['description']}', '{estate['features']}')", ESTATES_FOR_VERIFY))};"""
         sqlfile.write(sqlCommand)
         txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                  for estate in ESTATES_FOR_VERIFY]) + "\n")
@@ -196,7 +196,7 @@ if __name__ == '__main__':
             bulk_list = [generate_estate_dummy_data(
                 estate_id + i) for i in range(BULK_INSERT_COUNT)]
             estate_id += BULK_INSERT_COUNT
-            sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, view_count, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['view_count']}', '{estate['description']}', '{estate['features']}')", bulk_list))};"""
+            sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, popularity, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['popularity']}', '{estate['description']}', '{estate['features']}')", bulk_list))};"""
             sqlfile.write(sqlCommand)
             txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                      for estate in bulk_list]) + "\n")

--- a/webapp/deno/app.ts
+++ b/webapp/deno/app.ts
@@ -252,6 +252,14 @@ router.post("/api/chair/buy/:id", async (ctx) => {
       return;
     }
 
+    await db.transaction(async (conn) => {
+      await conn.execute(
+        "UPDATE chair SET stock = ? WHERE id = ?",
+        [chair.stock - 1, id],
+      );
+      await conn.execute("COMMIT");
+    });
+
     ctx.response.body = { ok: true };
   } catch (e) {
     ctx.response.status = 500;
@@ -482,13 +490,6 @@ router.get("/api/estate/:id", async (ctx) => {
       ctx.response.body = "Estate Not Found";
       return;
     }
-    await db.transaction(async (conn) => {
-      await conn.execute(
-        "UPDATE estate SET popularity = ? WHERE id = ?",
-        [estate.popularity + 1, id],
-      );
-      await conn.execute("COMMIT");
-    });
     ctx.response.body = camelcaseKeys(estate);
   } catch (e) {
     ctx.response.status = 500;

--- a/webapp/deno/app.ts
+++ b/webapp/deno/app.ts
@@ -195,7 +195,7 @@ router.get("/api/chair/search", async (ctx, next) => {
 
   const sqlprefix = "SELECT * FROM chair WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM chair WHERE ";
 
   try {
@@ -234,8 +234,8 @@ router.get("/api/chair/:id", async (ctx) => {
     }
     await db.transaction(async (conn) => {
       await conn.execute(
-        "UPDATE chair SET view_count = ? WHERE id = ?",
-        [chair.view_count + 1, id],
+        "UPDATE chair SET popularity = ? WHERE id = ?",
+        [chair.popularity + 1, id],
       );
       await conn.execute("COMMIT");
     });
@@ -376,7 +376,7 @@ router.get("/api/estate/search", async (ctx) => {
 
   const sqlprefix = "SELECT * FROM estate WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM estate WHERE ";
 
   try {
@@ -436,7 +436,7 @@ router.post("/api/estate/nazotte", async (ctx) => {
 
   try {
     const estates = await db.query(
-      "SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC, id ASC",
+      "SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC",
       [
         boundingbox.bottomright.latitude,
         boundingbox.topleft.latitude,
@@ -499,8 +499,8 @@ router.get("/api/estate/:id", async (ctx) => {
     }
     await db.transaction(async (conn) => {
       await conn.execute(
-        "UPDATE estate SET view_count = ? WHERE id = ?",
-        [estate.view_count + 1, id],
+        "UPDATE estate SET popularity = ? WHERE id = ?",
+        [estate.popularity + 1, id],
       );
       await conn.execute("COMMIT");
     });
@@ -524,7 +524,7 @@ router.post("/api/estate/req_doc/:id", async (ctx) => {
 
 router.get("/api/popular_estate", async (ctx) => {
   const es = await db.query(
-    "SELECT * FROM estate ORDER BY view_count DESC, id ASC LIMIT ?",
+    "SELECT * FROM estate ORDER BY popularity DESC, id ASC LIMIT ?",
     [LIMIT],
   );
   ctx.response.body = { estates: es.map(camelcaseKeys) };
@@ -538,7 +538,7 @@ router.get("/api/recommended_estate/:id", async (ctx) => {
     const h = chair.height;
     const d = chair.depth;
     const es = await db.query(
-      "SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY view_count DESC, id ASC LIMIT ?",
+      "SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY popularity DESC, id ASC LIMIT ?",
       [
         w,
         h,
@@ -565,7 +565,7 @@ router.get("/api/recommended_estate/:id", async (ctx) => {
 router.get("/api/popular_chair", async (ctx) => {
   try {
     const cs = await db.query(
-      "SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC, id ASC LIMIT ?",
+      "SELECT * FROM chair WHERE stock > 0 ORDER BY popularity DESC, id ASC LIMIT ?",
       [LIMIT],
     );
     ctx.response.body = { chairs: cs.map(camelcaseKeys) };

--- a/webapp/deno/app.ts
+++ b/webapp/deno/app.ts
@@ -232,13 +232,6 @@ router.get("/api/chair/:id", async (ctx) => {
       ctx.response.body = "Not Found";
       return;
     }
-    await db.transaction(async (conn) => {
-      await conn.execute(
-        "UPDATE chair SET popularity = ? WHERE id = ?",
-        [chair.popularity + 1, id],
-      );
-      await conn.execute("COMMIT");
-    });
     ctx.response.body = camelcaseKeys(chair);
   } catch (e) {
     ctx.response.status = 500;
@@ -258,14 +251,6 @@ router.post("/api/chair/buy/:id", async (ctx) => {
       ctx.response.body = "Not Found";
       return;
     }
-
-    await db.transaction(async (conn) => {
-      await conn.execute(
-        "UPDATE chair SET stock = ? WHERE id = ?",
-        [chair.stock - 1, id],
-      );
-      await conn.execute("COMMIT");
-    });
 
     ctx.response.body = { ok: true };
   } catch (e) {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -43,7 +43,7 @@ type Chair struct {
 	Color       string `db:"color" json:"color"`
 	Features    string `db:"features" json:"features"`
 	Kind        string `db:"kind" json:"kind"`
-	ViewCount   int64  `db:"view_count" json:"-"`
+	Popularity   int64  `db:"popularity" json:"-"`
 	Stock       int64  `db:"stock" json:"-"`
 }
 
@@ -69,7 +69,7 @@ type Estate struct {
 	DoorHeight  int64   `db:"door_height" json:"doorHeight"`
 	DoorWidth   int64   `db:"door_width" json:"doorWidth"`
 	Features    string  `db:"features" json:"features"`
-	ViewCount   int64   `db:"view_count" json:"-"`
+	Popularity   int64   `db:"popularity" json:"-"`
 }
 
 //EstateSearchResponse estate/searchへのレスポンスの形式
@@ -282,9 +282,9 @@ func getChairDetail(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.Exec("UPDATE chair SET view_count = ? WHERE id = ?", chair.ViewCount+1, id)
+	_, err = tx.Exec("UPDATE chair SET popularity = ? WHERE id = ?", chair.Popularity+1, id)
 	if err != nil {
-		c.Echo().Logger.Errorf("view_count of chair update failed : %v", err)
+		c.Echo().Logger.Errorf("popularity of chair update failed : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
@@ -408,7 +408,7 @@ func searchChairs(c echo.Context) error {
 	sqlstr := "SELECT * FROM chair WHERE "
 	searchCondition := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM chair WHERE "
 	err = db.Get(&chairs.Count, countsql+searchCondition, queryParams...)
@@ -498,7 +498,7 @@ func getChairSearchCondition(c echo.Context) error {
 func searchPopularChair(c echo.Context) error {
 	var popularChairs []Chair
 
-	sqlstr := `SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC, id ASC LIMIT ?`
+	sqlstr := `SELECT * FROM chair WHERE stock > 0 ORDER BY popularity DESC, id ASC LIMIT ?`
 
 	err := db.Select(&popularChairs, sqlstr, LIMIT)
 	if err != nil {
@@ -543,9 +543,9 @@ func getEstateDetail(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	_, err = tx.Exec("UPDATE estate SET view_count = ? WHERE id = ?", estate.ViewCount+1, id)
+	_, err = tx.Exec("UPDATE estate SET popularity = ? WHERE id = ?", estate.Popularity+1, id)
 	if err != nil {
-		c.Echo().Logger.Errorf("view_count update failed : %v", err)
+		c.Echo().Logger.Errorf("popularity update failed : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	err = tx.Commit()
@@ -658,7 +658,7 @@ func searchEstates(c echo.Context) error {
 	sqlstr := "SELECT * FROM estate WHERE "
 	searchQuery := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM estate WHERE "
 	err = db.Get(&estates.Count, countsql+searchQuery, searchQueryParameter...)
@@ -688,7 +688,7 @@ func searchEstates(c echo.Context) error {
 func searchPopularEstate(c echo.Context) error {
 	popularEstates := make([]Estate, 0, LIMIT)
 
-	sqlstr := `SELECT * FROM estate ORDER BY view_count DESC, id ASC LIMIT ?`
+	sqlstr := `SELECT * FROM estate ORDER BY popularity DESC, id ASC LIMIT ?`
 
 	err := db.Select(&popularEstates, sqlstr, LIMIT)
 	if err != nil {
@@ -732,7 +732,7 @@ func searchRecommendedEstateWithChair(c echo.Context) error {
 	w := chair.Width
 	h := chair.Height
 	d := chair.Depth
-	sqlstr = `SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY view_count DESC, id ASC LIMIT ?`
+	sqlstr = `SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY popularity DESC, id ASC LIMIT ?`
 	err = db.Select(&popularEstates, sqlstr, w, h, w, d, h, w, h, d, d, w, d, h, LIMIT)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -766,7 +766,7 @@ func searchEstateNazotte(c echo.Context) error {
 	b := coordinates.getBoundingBox()
 	estatesInBoundingBox := []Estate{}
 
-	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC, id ASC`
+	sqlstr := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC`
 
 	err = db.Select(&estatesInBoundingBox, sqlstr, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
 	if err == sql.ErrNoRows {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -275,25 +275,6 @@ func getChairDetail(c echo.Context) error {
 		return c.NoContent(http.StatusNotFound)
 	}
 
-	tx, err := db.Begin()
-	if err != nil {
-		c.Echo().Logger.Errorf("failed to create transaction : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-	defer tx.Rollback()
-
-	_, err = tx.Exec("UPDATE chair SET popularity = ? WHERE id = ?", chair.Popularity+1, id)
-	if err != nil {
-		c.Echo().Logger.Errorf("popularity of chair update failed : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		c.Echo().Logger.Errorf("transaction commit error : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-
 	return c.JSON(http.StatusOK, chair)
 }
 
@@ -534,23 +515,6 @@ func getEstateDetail(c echo.Context) error {
 			return c.NoContent(http.StatusNotFound)
 		}
 		c.Echo().Logger.Errorf("Database Execution error : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-	tx, err := db.Begin()
-	if err != nil {
-		c.Echo().Logger.Errorf("failed to create transaction : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-	defer tx.Rollback()
-
-	_, err = tx.Exec("UPDATE estate SET popularity = ? WHERE id = ?", estate.Popularity+1, id)
-	if err != nil {
-		c.Echo().Logger.Errorf("popularity update failed : %v", err)
-		return c.NoContent(http.StatusInternalServerError)
-	}
-	err = tx.Commit()
-	if err != nil {
-		c.Echo().Logger.Errorf("transaction commit error : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -43,7 +43,7 @@ type Chair struct {
 	Color       string `db:"color" json:"color"`
 	Features    string `db:"features" json:"features"`
 	Kind        string `db:"kind" json:"kind"`
-	Popularity   int64  `db:"popularity" json:"-"`
+	Popularity  int64  `db:"popularity" json:"-"`
 	Stock       int64  `db:"stock" json:"-"`
 }
 
@@ -69,7 +69,7 @@ type Estate struct {
 	DoorHeight  int64   `db:"door_height" json:"doorHeight"`
 	DoorWidth   int64   `db:"door_width" json:"doorWidth"`
 	Features    string  `db:"features" json:"features"`
-	Popularity   int64   `db:"popularity" json:"-"`
+	Popularity  int64   `db:"popularity" json:"-"`
 }
 
 //EstateSearchResponse estate/searchへのレスポンスの形式

--- a/webapp/mysql/db/0_Schema.sql
+++ b/webapp/mysql/db/0_Schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE isuumo.estate
     door_height INTEGER             NOT NULL,
     door_width  INTEGER             NOT NULL,
     features    VARCHAR(64)         NOT NULL,
-    view_count  INTEGER             NOT NULL
+    popularity  INTEGER             NOT NULL
 );
 
 CREATE TABLE isuumo.chair
@@ -33,6 +33,6 @@ CREATE TABLE isuumo.chair
     color       VARCHAR(64)     NOT NULL,
     features    VARCHAR(64)     NOT NULL,
     kind        VARCHAR(64)     NOT NULL,
-    view_count  INTEGER         NOT NULL,
+    popularity  INTEGER         NOT NULL,
     stock       INTEGER         NOT NULL
 );

--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -192,12 +192,8 @@ app.get("/api/chair/:id", async (req, res, next) => {
       res.status(404).send("Not Found");
       return;
     }
-    await connection.beginTransaction();
-    await query("UPDATE chair SET popularity = ? WHERE id = ?", [chair.popularity+1, id]);
-    await connection.commit();
     res.json(camelcaseKeys(chair));
   } catch (e) {
-    await connection.rollback();
     next(e);
   } finally {
     await connection.release();
@@ -426,12 +422,8 @@ app.get("/api/estate/:id", async (req, res, next) => {
       return;
     }
 
-    await connection.beginTransaction();
-    await query("UPDATE estate SET popularity = ? WHERE id = ?", [estate.popularity+1, id]);
-    await connection.commit();
     res.json(camelcaseKeys(estate));
   } catch (e) {
-    await connection.rollback();
     next(e);
   } finally {
     await connection.release();

--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -156,7 +156,7 @@ app.get("/api/chair/search", async (req, res, next) => {
   
   const sqlprefix = "SELECT * FROM chair WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM chair WHERE ";
 
   const getConnection = promisify(db.getConnection.bind(db));
@@ -193,7 +193,7 @@ app.get("/api/chair/:id", async (req, res, next) => {
       return;
     }
     await connection.beginTransaction();
-    await query("UPDATE chair SET view_count = ? WHERE id = ?", [chair.view_count+1, id]);
+    await query("UPDATE chair SET popularity = ? WHERE id = ?", [chair.popularity+1, id]);
     await connection.commit();
     res.json(camelcaseKeys(chair));
   } catch (e) {
@@ -314,7 +314,7 @@ app.get("/api/estate/search", async (req, res, next) => {
   
   const sqlprefix = "SELECT * FROM estate WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY view_count DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM estate WHERE ";
 
   const getConnection = promisify(db.getConnection.bind(db));
@@ -378,7 +378,7 @@ app.post("/api/estate/nazotte", async (req, res, next) => {
   const connection = await getConnection();
   const query = promisify(connection.query.bind(connection));
   try {
-    const estates = await query("SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY view_count DESC, id ASC", [
+    const estates = await query("SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC", [
       boundingbox.bottomright.latitude, boundingbox.topleft.latitude, boundingbox.bottomright.longitude, boundingbox.topleft.longitude,
     ]);
 
@@ -427,7 +427,7 @@ app.get("/api/estate/:id", async (req, res, next) => {
     }
 
     await connection.beginTransaction();
-    await query("UPDATE estate SET view_count = ? WHERE id = ?", [estate.view_count+1, id]);
+    await query("UPDATE estate SET popularity = ? WHERE id = ?", [estate.popularity+1, id]);
     await connection.commit();
     res.json(camelcaseKeys(estate));
   } catch (e) {
@@ -443,7 +443,7 @@ app.get("/api/popular_estate", async (req, res, next) => {
   const connection = await getConnection();
   const query = promisify(connection.query.bind(connection));
   try {
-    const es = await query("SELECT * FROM estate ORDER BY view_count DESC, id ASC LIMIT ?", [LIMIT]);
+    const es = await query("SELECT * FROM estate ORDER BY popularity DESC, id ASC LIMIT ?", [LIMIT]);
     const estates = es.map((estate) => camelcaseKeys(estate)); 
     res.json({estates});
   } catch (e) {
@@ -463,7 +463,7 @@ app.get("/api/recommended_estate/:id", async (req, res, next) => {
     const w = chair.width;
     const h = chair.height;
     const d = chair.depth;
-    const es = await query("SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY view_count DESC, id ASC LIMIT ?", [
+    const es = await query("SELECT * FROM estate where (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>= ?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) OR (door_width >= ? AND door_height>=?) ORDER BY popularity DESC, id ASC LIMIT ?", [
       w, h, w, d, h, w, h, d, d, w, d, h, LIMIT
     ]);
     const estates = es.map((estate) => camelcaseKeys(estate)); 
@@ -480,7 +480,7 @@ app.get("/api/popular_chair", async (req, res, next) => {
   const connection = await getConnection();
   const query = promisify(connection.query.bind(connection));
   try {
-    const cs = await query("SELECT * FROM chair WHERE stock > 0 ORDER BY view_count DESC, id ASC LIMIT ?", [LIMIT]);
+    const cs = await query("SELECT * FROM chair WHERE stock > 0 ORDER BY popularity DESC, id ASC LIMIT ?", [LIMIT]);
     const chairs = cs.map((chair) => camelcaseKeys(chair)); 
     res.json({ chairs });
   } catch (e) {


### PR DESCRIPTION
## 目的

- `view_count` の増加による問題の難化は本問題において本質的ではないという指摘を受けた
- また、オンメモリにデータを載せる際の抑制にもなりづらいという指摘を受けた


## 解決方法

- `view_count` は `popularity` という column 名に rename した
- `popularity` は詳細閲覧によるインクリメントがされないように変更した


## 動作確認

- [x] ベンチマークが正常に動作することを確認


## 参考文献 (Optional)

- なし
