### PR TITLE
[bench] context関係のエラーがfailureによってwrapされていても判別可能にする

### DIFF
--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -2,6 +2,7 @@ package fails
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 	"time"
@@ -92,7 +93,8 @@ func (e *Errors) Add(err error, label ErrorLabel) {
 		return
 	}
 
-	if err == context.DeadlineExceeded || err == context.Canceled {
+	cause := failure.CauseOf(err)
+	if errors.Is(cause, context.DeadlineExceeded) || errors.Is(cause, context.Canceled) {
 		return
 	}
 


### PR DESCRIPTION
## 目的

- `fails` にて、　context のキャンセルやタイムアウトは追加しないようにしていた
- しかし、エラーが Wrap されていた場合にはこれらのチェックを通り抜けてしまう


## 解決方法

- `failure.CauseOf` や `errors.Is` を使うことで対応した
	-　検証: https://play.golang.org/p/SLUQfPvi9a_O


## 動作確認

- [x] ベンチマークにて予期せぬエラーが発生しないことを確認


## 参考文献 (Optional)

- https://github.com/morikuni/failure/blob/d9e6cd057a5314cd96c023ec6cec7ccda647e5bf/iterator.go#L67-L80
