### PR TITLE
[bench] initializeが失敗した際の出力には使用言語を空文字に設定する

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -97,7 +97,7 @@ func main() {
 			Pass:     false,
 			Score:    0,
 			Messages: uniqMsgs(eMsgs),
-			Language: initRes.Language,
+			Language: "",
 		}
 		json.NewEncoder(os.Stdout).Encode(output)
 


### PR DESCRIPTION
## 目的

- `POST /initialize` に失敗した場合にベンチマーカーが null pointer を引き起こしてしまう


## 解決方法

- `scenario.Initialize` の返り値が `(nil, err)` なのに第一引数の `.Language` にアクセスしていたのが原因だった
- `POST /initialize` に失敗した場合には使用言語には空文字を設定する


## 動作確認

- [x] nil pointer が発生しないことを確認


## 参考文献 (Optional)

- なし
