### PR TITLE
[webapp] イス・物件検索結果は価格や賃料の安い順でソートする

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -104,7 +104,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return nil
 	}
 
-	if !isChairsOrderedByPopularity(cr.Chairs, t) {
+	if !isChairsOrderedByPrice(cr.Chairs, t) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -132,7 +132,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isChairsOrderedByPopularity(cr.Chairs, t) {
+			if !isChairsOrderedByPrice(cr.Chairs, t) {
 				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)

--- a/bench/scenario/check.go
+++ b/bench/scenario/check.go
@@ -14,6 +14,23 @@ func isEstateEqualToAsset(e *asset.Estate) bool {
 	return estate.Equal(e)
 }
 
+func isEstatesOrderedByRent(e []asset.Estate) bool {
+	if len(e) == 0 {
+		return true
+	}
+
+	rent := e[0].Rent
+	for _, estate := range e {
+		r := estate.Rent
+
+		if rent > r {
+			return false
+		}
+		rent = r
+	}
+	return true
+}
+
 func isEstatesOrderedByPopularity(e []asset.Estate) bool {
 	var popularity int64 = -1
 	for i, estate := range e {
@@ -48,6 +65,28 @@ func isChairSoldOutAt(c *asset.Chair, t time.Time) bool {
 		return false
 	}
 	return t.After(*soldOutTime)
+}
+
+func isChairsOrderedByPrice(c []asset.Chair, t time.Time) bool {
+	if len(c) == 0 {
+		return true
+	}
+
+	price := c[0].Price
+	for _, chair := range c {
+		_chair, err := asset.GetChairFromID(chair.ID)
+		if err != nil || isChairSoldOutAt(_chair, t) {
+			return false
+		}
+
+		p := _chair.Price
+
+		if price > p {
+			return false
+		}
+		price = p
+	}
+	return true
 }
 
 func isChairsOrderedByPopularity(c []asset.Chair, t time.Time) bool {

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -99,7 +99,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return nil
 	}
 
-	if !isEstatesOrderedByPopularity(er.Estates) {
+	if !isEstatesOrderedByRent(er.Estates) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
@@ -126,7 +126,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isEstatesOrderedByPopularity(er.Estates) {
+			if !isEstatesOrderedByRent(er.Estates) {
 				err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)

--- a/webapp/deno/app.ts
+++ b/webapp/deno/app.ts
@@ -195,7 +195,7 @@ router.get("/api/chair/search", async (ctx, next) => {
 
   const sqlprefix = "SELECT * FROM chair WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY price ASC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM chair WHERE ";
 
   try {
@@ -369,7 +369,7 @@ router.get("/api/estate/search", async (ctx) => {
 
   const sqlprefix = "SELECT * FROM estate WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY rent ASC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM estate WHERE ";
 
   try {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -506,7 +506,7 @@ func searchChairs(c echo.Context) error {
 	sqlstr := "SELECT * FROM chair WHERE "
 	searchCondition := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY price ASC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM chair WHERE "
 	err = db.Get(&chairs.Count, countsql+searchCondition, queryParams...)
@@ -794,7 +794,7 @@ func searchEstates(c echo.Context) error {
 	sqlstr := "SELECT * FROM estate WHERE "
 	searchQuery := strings.Join(searchQueryArray, " AND ")
 
-	limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
+	limitOffset := " ORDER BY rent ASC, id ASC LIMIT ? OFFSET ?"
 
 	countsql := "SELECT COUNT(*) FROM estate WHERE "
 	err = db.Get(&estates.Count, countsql+searchQuery, searchQueryParameter...)

--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -156,7 +156,7 @@ app.get("/api/chair/search", async (req, res, next) => {
   
   const sqlprefix = "SELECT * FROM chair WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY price ASC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM chair WHERE ";
 
   const getConnection = promisify(db.getConnection.bind(db));
@@ -310,7 +310,7 @@ app.get("/api/estate/search", async (req, res, next) => {
   
   const sqlprefix = "SELECT * FROM estate WHERE ";
   const searchCondition = searchQueries.join(" AND ");
-  const limitOffset = " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?";
+  const limitOffset = " ORDER BY rent ASC, id ASC LIMIT ? OFFSET ?";
   const countprefix = "SELECT COUNT(*) as count FROM estate WHERE ";
 
   const getConnection = promisify(db.getConnection.bind(db));


### PR DESCRIPTION
## 目的

- 最初に index 貼れば早くなるような問題を用意してあげたい
- 逆順ソートは初心者に優しくないという指摘を受けたため、 `ORDER BY ?? ASC` をしてあげたい


## 解決方法

- アイデアとして、検索結果はイスの価格や物件の賃料の安い順でソートする


## 別のアイデア

- 検索にソートオプションを付ける


## 動作確認

- [x] bench
- [x] webapp/go
- [x] webapp/nodejs
- [x] webapp/deno


## 参考文献 (Optional)

- なし
