### PR TITLE
[bench] イス・物件検索後に詳細ページを複数訪問する

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -5,6 +5,8 @@ import "time"
 const (
 	NumOfCheckChairSearchPaging    = 3
 	NumOfCheckEstateSearchPaging   = 3
+	NumOfCheckChairDetailPage      = 7
+	NumOfCheckEstateDetailPage     = 3
 	PerPageOfChairSearch           = 30
 	PerPageOfEstateSearch          = 30
 	MaxLengthOfNazotteResponse     = 50

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -145,34 +145,43 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	// Get detail of Chair
-	randomPosition := rand.Intn(len(cr.Chairs))
-	targetID := cr.Chairs[randomPosition].ID
-	t = time.Now()
-	chair, er, err := c.AccessChairDetailPage(ctx, targetID)
+	var targetID int64 = -1
+	var chair *asset.Chair
+	var er *client.EstatesResponse
+	for i := 0; i < parameter.NumOfCheckChairDetailPage; i++ {
+		randomPosition := rand.Intn(len(cr.Chairs))
+		targetID = cr.Chairs[randomPosition].ID
+		t = time.Now()
+		chair, er, err = c.AccessChairDetailPage(ctx, targetID)
 
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
+
+		if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
+			return failure.New(fails.ErrTimeout)
+		}
+
+		if chair == nil {
+			return nil
+		}
+
+		if !isChairEqualToAsset(chair) {
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: イス情報が不正です"))
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
+
+		if !isEstatesOrderedByPopularity(er.Estates) {
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: おすすめ結果が不正です"))
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
 	}
 
-	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
-		return failure.New(fails.ErrTimeout)
-	}
-
-	if chair == nil {
+	if targetID == -1 {
 		return nil
-	}
-
-	if !isChairEqualToAsset(chair) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: イス情報が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
-	}
-
-	if !isEstatesOrderedByPopularity(er.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: おすすめ結果が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
 	}
 
 	// Buy Chair
@@ -185,23 +194,30 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	// Get detail of Estate
-	randomPosition = rand.Intn(len(er.Estates))
-	targetID = er.Estates[randomPosition].ID
-	t = time.Now()
-	e, err := c.AccessEstateDetailPage(ctx, targetID)
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
+	targetID = -1
+	for i := 0; i < parameter.NumOfCheckEstateDetailPage; i++ {
+		randomPosition := rand.Intn(len(er.Estates))
+		targetID = er.Estates[randomPosition].ID
+		t = time.Now()
+		e, err := c.AccessEstateDetailPage(ctx, targetID)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
+
+		if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
+			return failure.New(fails.ErrTimeout)
+		}
+
+		if !isEstateEqualToAsset(e) {
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
 	}
 
-	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
-		return failure.New(fails.ErrTimeout)
-	}
-
-	if !isEstateEqualToAsset(e) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
-		return failure.New(fails.ErrApplication)
+	if targetID == -1 {
+		return nil
 	}
 
 	// Request docs of Estate

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -139,24 +139,31 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	// Get Details with ID from previously searched list
-	randomPosition := rand.Intn(len(er.Estates))
-	targetID := er.Estates[randomPosition].ID
-	t = time.Now()
-	e, err := c.AccessEstateDetailPage(ctx, targetID)
-	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
-		return failure.New(fails.ErrApplication)
+	var targetID int64 = -1
+	for i := 0; i < parameter.NumOfCheckEstateDetailPage; i++ {
+		randomPosition := rand.Intn(len(er.Estates))
+		targetID = er.Estates[randomPosition].ID
+		t = time.Now()
+		e, err := c.AccessEstateDetailPage(ctx, targetID)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
+
+		if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
+			return failure.New(fails.ErrTimeout)
+		}
+
+		estate, err := asset.GetEstateFromID(e.ID)
+		if err != nil || !e.Equal(estate) {
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			return failure.New(fails.ErrApplication)
+		}
 	}
 
-	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
-		return failure.New(fails.ErrTimeout)
-	}
-
-	estate, err := asset.GetEstateFromID(e.ID)
-	if err != nil || !e.Equal(estate) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
-		return failure.New(fails.ErrApplication)
+	if targetID == -1 {
+		return nil
 	}
 
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))


### PR DESCRIPTION
## 目的

- `GET /api/recommended_estate/:id` の叩かれる回数が少ないため、ボトルネックになりづらかった


## 解決方法

- イス・物件検索の後に詳細ページを複数回訪問するように変更


## 動作確認

- [x] ベンチマーク時にタイムアウト以外のエラーメッセージがないことを確認


## 参考文献 (Optional)

- なし
