### PR TITLE
[webapp] イス検索時にkindのparamを考慮していなかったのを修正

### DIFF
--- a/webapp/deno/app.ts
+++ b/webapp/deno/app.ts
@@ -76,6 +76,7 @@ router.get("/api/chair/search", async (ctx, next) => {
     heightRangeId,
     widthRangeId,
     depthRangeId,
+    kind,
     color,
     features,
     page,
@@ -156,6 +157,11 @@ router.get("/api/chair/search", async (ctx, next) => {
       searchQueries.push("depth < ? ");
       queryParams.push(chairDepth.max);
     }
+  }
+
+  if (kind != null) {
+    searchQueries.push("kind = ? ");
+    queryParams.push(kind);
   }
 
   if (color != null) {

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -470,6 +470,11 @@ func searchChairs(c echo.Context) error {
 		}
 	}
 
+	if c.QueryParam("kind") != "" {
+		searchQueryArray = append(searchQueryArray, "kind = ?")
+		queryParams = append(queryParams, c.QueryParam("kind"))
+	}
+
 	if c.QueryParam("color") != "" {
 		searchQueryArray = append(searchQueryArray, "color = ?")
 		queryParams = append(queryParams, c.QueryParam("color"))

--- a/webapp/nodejs/app.js
+++ b/webapp/nodejs/app.js
@@ -47,7 +47,7 @@ app.post("/initialize", async (req, res, next) => {
 app.get("/api/chair/search", async (req, res, next) => {
   const searchQueries = [];
   const queryParams = [];
-  const {priceRangeId, heightRangeId, widthRangeId, depthRangeId, color, features, page, perPage, } = req.query;
+  const {priceRangeId, heightRangeId, widthRangeId, depthRangeId, kind, color, features, page, perPage, } = req.query;
 
   if (priceRangeId != null) {
     const chairPrice = chairSearchCondition["price"].ranges[priceRangeId];
@@ -119,6 +119,11 @@ app.get("/api/chair/search", async (req, res, next) => {
       searchQueries.push("depth < ? ");
       queryParams.push(chairDepth.max);
     }
+  }
+
+  if (kind != null) {
+    searchQueries.push("kind = ? ");
+    queryParams.push(kind);
   }
 
   if (color != null) {


### PR DESCRIPTION
## 目的

- `page` , `perPage` , `kind` のみをセットした `GET /api/chair/search` が 400 で失敗していた
- これは `kind` が検索条件として考慮されておらず、条件が何も設定されていないと判断されていたのが原因だった


## 解決方法

- 検索時に `kind` を考慮するように修正


## 動作確認

- [x] `kind` を考慮した検索結果になっていることを確認

```sh
❯ curl -D - 'localhost:1323/api/chair/search?kind=%E3%83%8F%E3%83%B3%E3%83%A2%E3%83%83%E3%82%AF&page=0&perPage=1'
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Date: Thu, 20 Aug 2020 03:11:39 GMT
Content-Length: 674

{
  "count": 7581,
  "chairs": [
    {
      "id": 25512,
      "name": "[期間限定]アンティークなオフィスチェア",
      "description": "婿取はよそ目にはいゝやうだけれども人一倍辛い、かう誰かゞ言つたことも思ひ出されて、今までの姉の立場が抉り出したやうにはつきりとわかつたやうな氣がした。",
      "thumbnail": "/images/chair/f24e37b696e335c83d552bf5509f3a5cce5891c35e384b55e487b5c1c0151172.png",
      "price": 1001,
      "height": 106,
      "width": 113,
      "depth": 51,
      "color": "黄",
      "features": "メッシュ貼地",
      "kind": "ハンモック"
    }
  ]
}
```


## 参考文献 (Optional)

- なし
