### PR TITLE
[bench] 負荷レベルに応じて検索条件が複雑化するように変更

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -3,9 +3,7 @@ package scenario
 import (
 	"context"
 	"math/rand"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/morikuni/failure"
@@ -15,51 +13,6 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
-
-func createRandomChairSearchQuery() (url.Values, error) {
-	condition, err := asset.GetChairSearchCondition()
-	if err != nil {
-		return nil, err
-	}
-
-	q := url.Values{}
-	priceRangeID := condition.Price.Ranges[rand.Intn(len(condition.Price.Ranges))].ID
-	if (rand.Intn(100) % 10) == 0 {
-		q.Set("priceRangeId", strconv.FormatInt(priceRangeID, 10))
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		heightRangeID := condition.Height.Ranges[rand.Intn(len(condition.Height.Ranges))].ID
-		q.Set("heightRangeId", strconv.FormatInt(heightRangeID, 10))
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		widthRangeID := condition.Width.Ranges[rand.Intn(len(condition.Width.Ranges))].ID
-		q.Set("widthRangeId", strconv.FormatInt(widthRangeID, 10))
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		depthRangeID := condition.Depth.Ranges[rand.Intn(len(condition.Depth.Ranges))].ID
-		q.Set("depthRangeId", strconv.FormatInt(depthRangeID, 10))
-	}
-
-	if (rand.Intn(100) % 10) == 0 {
-		q.Set("kind", condition.Kind.List[rand.Intn(len(condition.Kind.List))])
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		q.Set("color", condition.Color.List[rand.Intn(len(condition.Color.List))])
-	}
-	features := make([]string, len(condition.Feature.List))
-	copy(features, condition.Feature.List)
-	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)) + 1
-	if featureLength > 3 {
-		featureLength = rand.Intn(3) + 1
-	}
-	q.Set("features", strings.Join(features[:featureLength], ","))
-
-	q.Set("perPage", strconv.Itoa(parameter.PerPageOfChairSearch))
-	q.Set("page", "0")
-
-	return q, nil
-}
 
 func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -3,9 +3,7 @@ package scenario
 import (
 	"context"
 	"math/rand"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/morikuni/failure"
@@ -15,45 +13,6 @@ import (
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
 )
-
-var estateFeatureList = []string{
-	"バストイレ別",
-	"駅から徒歩5分",
-	"ペット飼育可能",
-}
-
-func createRandomEstateSearchQuery() (url.Values, error) {
-	condition, err := asset.GetEstateSearchCondition()
-	if err != nil {
-		return nil, err
-	}
-
-	q := url.Values{}
-	if (rand.Intn(100) % 10) == 0 {
-		rentRangeID := condition.Rent.Ranges[rand.Intn(len(condition.Rent.Ranges))].ID
-		q.Set("rentRangeId", strconv.FormatInt(rentRangeID, 10))
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		doorHeightRangeID := condition.DoorHeight.Ranges[rand.Intn(len(condition.DoorHeight.Ranges))].ID
-		q.Set("doorHeightRangeId", strconv.FormatInt(doorHeightRangeID, 10))
-	}
-	if (rand.Intn(100) % 10) == 0 {
-		doorWidthRangeID := condition.DoorWidth.Ranges[rand.Intn(len(condition.DoorWidth.Ranges))].ID
-		q.Set("doorWidthRangeId", strconv.FormatInt(doorWidthRangeID, 10))
-	}
-	features := make([]string, len(condition.Feature.List))
-	copy(features, condition.Feature.List)
-	rand.Shuffle(len(features), func(i, j int) { features[i], features[j] = features[j], features[i] })
-	featureLength := rand.Intn(len(features)) + 1
-	if featureLength > 3 {
-		featureLength = rand.Intn(3) + 1
-	}
-	q.Set("features", strings.Join(features[:featureLength], ","))
-	q.Set("perPage", strconv.Itoa(parameter.PerPageOfEstateSearch))
-	q.Set("page", "0")
-
-	return q, nil
-}
 
 func estateSearchScenario(ctx context.Context, c *client.Client) error {
 

--- a/bench/scenario/searchQuery.go
+++ b/bench/scenario/searchQuery.go
@@ -1,0 +1,107 @@
+package scenario
+
+import (
+	"math/rand"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
+	"github.com/isucon10-qualify/isucon10-qualify/bench/parameter"
+)
+
+func randomTakeMany(slice []string, minLength, maxLength int) []string {
+	s := make([]string, len(slice))
+	copy(s, slice)
+	rand.Shuffle(len(s), func(i, j int) { s[i], s[j] = s[j], s[i] })
+	length := rand.Intn(maxLength-minLength) + minLength
+	return s[:length]
+}
+
+func createRandomChairSearchQuery() (url.Values, error) {
+	condition, err := asset.GetChairSearchCondition()
+	if err != nil {
+		return nil, err
+	}
+
+	level := GetLoadLevel()
+	paramNum := int(level/2 + 1)
+
+	q := url.Values{}
+	q.Set("perPage", strconv.Itoa(parameter.PerPageOfChairSearch))
+	q.Set("page", "0")
+
+	for i := 0; i < paramNum; i++ {
+		switch rand.Intn(7) {
+		case 0:
+			priceRangeID := condition.Price.Ranges[rand.Intn(len(condition.Price.Ranges))].ID
+			q.Set("priceRangeId", strconv.FormatInt(priceRangeID, 10))
+
+		case 1:
+			heightRangeID := condition.Height.Ranges[rand.Intn(len(condition.Height.Ranges))].ID
+			q.Set("heightRangeId", strconv.FormatInt(heightRangeID, 10))
+
+		case 2:
+			widthRangeID := condition.Width.Ranges[rand.Intn(len(condition.Width.Ranges))].ID
+			q.Set("widthRangeId", strconv.FormatInt(widthRangeID, 10))
+
+		case 3:
+			depthRangeID := condition.Depth.Ranges[rand.Intn(len(condition.Depth.Ranges))].ID
+			q.Set("depthRangeId", strconv.FormatInt(depthRangeID, 10))
+
+		case 4:
+			kind := condition.Kind.List[rand.Intn(len(condition.Kind.List))]
+			q.Set("kind", kind)
+
+		case 5:
+			color := condition.Color.List[rand.Intn(len(condition.Color.List))]
+			q.Set("color", color)
+
+		case 6:
+			features := strings.Join(randomTakeMany(condition.Feature.List, 1, 3), ",")
+			q.Set("features", features)
+		}
+	}
+
+	return q, nil
+}
+
+func createRandomEstateSearchQuery() (url.Values, error) {
+	condition, err := asset.GetEstateSearchCondition()
+	if err != nil {
+		return nil, err
+	}
+
+	level := GetLoadLevel()
+	paramNum := int(level/2 + 1)
+
+	q := url.Values{}
+	q.Set("perPage", strconv.Itoa(parameter.PerPageOfEstateSearch))
+	q.Set("page", "0")
+
+	for i := 0; i < paramNum; i++ {
+		switch rand.Intn(5) {
+		case 0:
+			rentRangeID := condition.Rent.Ranges[rand.Intn(len(condition.Rent.Ranges))].ID
+			q.Set("rentRangeId", strconv.FormatInt(rentRangeID, 10))
+
+		case 1:
+			rentRangeID := condition.Rent.Ranges[rand.Intn(len(condition.Rent.Ranges))].ID
+			q.Set("rentRangeId", strconv.FormatInt(rentRangeID, 10))
+
+		case 2:
+			doorHeightRangeID := condition.DoorHeight.Ranges[rand.Intn(len(condition.DoorHeight.Ranges))].ID
+			q.Set("doorHeightRangeId", strconv.FormatInt(doorHeightRangeID, 10))
+
+		case 3:
+			doorWidthRangeID := condition.DoorWidth.Ranges[rand.Intn(len(condition.DoorWidth.Ranges))].ID
+			q.Set("doorWidthRangeId", strconv.FormatInt(doorWidthRangeID, 10))
+
+		case 4:
+			features := strings.Join(randomTakeMany(condition.Feature.List, 1, 3), ",")
+			q.Set("features", features)
+		}
+	}
+
+	return q, nil
+}


### PR DESCRIPTION
## 目的

- 最初のボトルネックを index 貼るだけで解消できるようなものにしたい
- イス・物件検索は検索条件が複雑すぎる故にチューニングが困難だった


## 解決方法

- 負荷レベルの上昇に応じて、検索条件が複雑になるように変更
  - 現在は、単純に `int(level / 2)` 種類の条件を含む検索を行う


## 動作確認

- [x] ベンチマークが成功することを確認
	- #89 が原因でエラーメッセージが発生するケースが多かった


## 参考文献 (Optional)

- なし
