### PR TITLE
[bench] 1シナリオ内で条件をを変えた検索を複数回行う

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -3,6 +3,8 @@ package parameter
 import "time"
 
 const (
+	NumOfSearchChairInScenario     = 5
+	NumOfSearchEstateInScenario    = 5
 	NumOfCheckChairSearchPaging    = 3
 	NumOfCheckEstateSearchPaging   = 3
 	NumOfCheckChairDetailPage      = 7


### PR DESCRIPTION
## 目的

- 複雑な検索条件によっては、結果が 0 件である可能性がある
	- この場合、そこでシナリオは中断されて再度新しいシナリオが実行されてしまい CV には繋がらない
- `GET /api/popular_estate` , `GET /api/popular_chair` が重い
	- `GET /api/estate/search` や `GET /api/chair/search` は比較的軽量なため、初期段階だとここがボトルネックになりにくい


## 解決方法

- 1 回のシナリオにて、条件を変えた検索を複数回行うように変更した
	- 複数回行うことで、 検索結果が 0 件でも別の条件での検索に期待ができる
	- 回数を多くすることでイス・物件検索による負荷の割合を上昇させる


## 動作確認

- [x] ベンチマークが正常に終了することを確認


## 参考文献 (Optional)

- なし
