### PR TITLE
[bench] レスポンスボディの内容のcheckに失敗した際のエラーメッセージを変更

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -23,13 +23,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -73,7 +73,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 
 		if !isChairsOrderedByPopularity(_cr.Chairs, t) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -104,7 +104,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if !isChairsOrderedByPopularity(cr.Chairs, t) {
-				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: 検索結果が不正です"))
+				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
@@ -145,13 +145,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 
 		if !isChairEqualToAsset(chair) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: イス情報が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
 		if !isEstatesOrderedByPopularity(er.Estates) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: おすすめ結果が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -187,7 +187,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 
 		if !isEstateEqualToAsset(e) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -189,13 +189,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -232,13 +232,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	if len(er.Estates) > parameter.MaxLengthOfNazotteResponse {
-		err = failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if !isEstatesInBoundingBox(er.Estates, boundingBox) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/nazotte: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/nazotte: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -262,7 +262,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 
 	estate, err := asset.GetEstateFromID(e.ID)
 	if err != nil || !e.Equal(estate) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -24,13 +24,13 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	}
 
 	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 検索結果が不正です"))
+		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -74,7 +74,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 
 		if !isEstatesOrderedByPopularity(_er.Estates) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -106,7 +106,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if !isEstatesOrderedByPopularity(er.Estates) {
-				err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 検索結果が不正です"))
+				err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
@@ -141,7 +141,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 
 		estate, err := asset.GetEstateFromID(e.ID)
 		if err != nil || !e.Equal(estate) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: 物件情報が不正です"))
+			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -81,7 +81,7 @@ func verifyChairSearchCondition(ctx context.Context, c *client.Client, filePath 
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search/condition: イスの検索条件が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search/condition: レスポンスの内容が不正です"))
 		}
 
 		var expected *asset.ChairSearchCondition
@@ -92,12 +92,12 @@ func verifyChairSearchCondition(ctx context.Context, c *client.Client, filePath 
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreChairUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search/condition: イスの検索条件が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search/condition: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search/condition: イスの検索条件が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search/condition: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -120,7 +120,7 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.ChairsResponse
@@ -131,12 +131,12 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreChairUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: イスの検索結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -154,7 +154,7 @@ func verifyEstateSearchCondition(ctx context.Context, c *client.Client, filePath
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search/condition: 物件の検索条件が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search/condition: レスポンスの内容が不正です"))
 		}
 
 		var expected *asset.EstateSearchCondition
@@ -165,12 +165,12 @@ func verifyEstateSearchCondition(ctx context.Context, c *client.Client, filePath
 
 		if !cmp.Equal(*expected, *actual) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search/condition: 物件の検索条件が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search/condition: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search/condition: 物件の検索条件が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search/condition: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -193,7 +193,7 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.EstatesResponse
@@ -204,12 +204,12 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: 物件の検索結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -227,7 +227,7 @@ func verifyLowPricedChair(ctx context.Context, c *client.Client, filePath string
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: イスのおすすめ結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.ChairsResponse
@@ -238,12 +238,12 @@ func verifyLowPricedChair(ctx context.Context, c *client.Client, filePath string
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreChairUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: イスのおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: イスのおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -261,7 +261,7 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 物件のおすすめ結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.EstatesResponse
@@ -272,12 +272,12 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -304,7 +304,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: 物件のおすすめ結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.EstatesResponse
@@ -314,12 +314,12 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		}
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: 物件のおすすめ結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: 物件のおすすめ結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
 		}
 	}
 
@@ -343,7 +343,7 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 	switch snapshot.Response.StatusCode {
 	case http.StatusOK:
 		if err != nil {
-			return failure.Translate(err, fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
+			return failure.Translate(err, fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"))
 		}
 
 		var expected *client.EstatesResponse
@@ -354,12 +354,12 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"), failure.Messagef("snapshot: %s", filePath))
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 	default:
 		if err == nil {
-			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: 物件の検索結果が不正です"))
+			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"))
 		}
 	}
 


### PR DESCRIPTION
## 目的

- #93 により適切なエラーメッセージの文言を考えるのが難しくなった


## 解決方法

- レスポンスボディの内容が check に失敗した場合には「レスポンスの内容が不正です」というエラーメッセージを返すように変更


## 動作確認

- [x] ベンチマーク時に予期せぬエラーが発生しないことを確認


## 参考文献 (Optional)

- なし
