### PR TITLE
[bench] pointの近傍取得関数を削除

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -12,7 +12,6 @@ const (
 	PerPageOfChairSearch           = 30
 	PerPageOfEstateSearch          = 30
 	MaxLengthOfNazotteResponse     = 50
-	NeighborhoodRadiusOfNazotte    = 1e-6
 	SleepTimeOnFailScenario        = 1500 * time.Millisecond
 	SleepSwingOnFailScenario       = 500 // * time.Millisecond
 	SleepTimeOnUserAway            = 500 * time.Millisecond

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -129,16 +129,6 @@ func ToCoordinates(po []point) *client.Coordinates {
 	return &client.Coordinates{Coordinates: r}
 }
 
-// 点Pの周りの4点を返す
-func getPointNeighbors(p point) []point {
-	return []point{
-		{Latitude: p.Latitude - parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + parameter.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude + parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude + parameter.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude - parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - parameter.NeighborhoodRadiusOfNazotte},
-		{Latitude: p.Latitude + parameter.NeighborhoodRadiusOfNazotte, Longitude: p.Longitude - parameter.NeighborhoodRadiusOfNazotte},
-	}
-}
-
 func contains(s []int64, e int64) bool {
 	for _, v := range s {
 		if e == v {


### PR DESCRIPTION
## 目的

- 不要になった関数が残っていた


## 解決方法

- 利用タイミングがないので削除


## 動作確認

- [x] ベンチマークが正常に動作することを確認


## 参考文献 (Optional)

- なし
