### PR TITLE
[bench] イス・物件検索のfeaturesは負荷レベル2以降から行う

### DIFF
--- a/bench/scenario/searchQuery.go
+++ b/bench/scenario/searchQuery.go
@@ -33,7 +33,12 @@ func createRandomChairSearchQuery() (url.Values, error) {
 	q.Set("page", "0")
 
 	for i := 0; i < paramNum; i++ {
-		switch rand.Intn(7) {
+		r := rand.Intn(6)
+		if level >= 2 {
+			r = rand.Intn(7)
+		}
+
+		switch r {
 		case 0:
 			priceRangeID := condition.Price.Ranges[rand.Intn(len(condition.Price.Ranges))].ID
 			q.Set("priceRangeId", strconv.FormatInt(priceRangeID, 10))
@@ -81,7 +86,12 @@ func createRandomEstateSearchQuery() (url.Values, error) {
 	q.Set("page", "0")
 
 	for i := 0; i < paramNum; i++ {
-		switch rand.Intn(4) {
+		r := rand.Intn(3)
+		if level >= 2 {
+			r = rand.Intn(4)
+		}
+
+		switch r {
 		case 0:
 			rentRangeID := condition.Rent.Ranges[rand.Intn(len(condition.Rent.Ranges))].ID
 			q.Set("rentRangeId", strconv.FormatInt(rentRangeID, 10))


### PR DESCRIPTION
## 目的

- `features` を含むイス・物件検索が初期段階でボトルネックになってしまい、点数の上昇が難しいことがわかった
- これを回避するための策が必要


## 解決方法

- `features` を含むイス・物件検索を段階的に導入する


## 動作確認

- [x] `features` を含むイス・物件検索が初期段階で行われないことを確認


## 参考文献 (Optional)

- なし
