### PR TITLE
[bench] イス・物件検索で有効な検索が行えなかった場合にnil accessが発生していたのを修正

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -117,7 +117,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 	}
 
-	if len(cr.Chairs) == 0 {
+	if cr != nil || len(cr.Chairs) == 0 {
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			return failure.New(fails.ErrTimeout)
 		}
 
-		if chair == nil {
+		if chair == nil || len(er.Estates) == 0 {
 			return nil
 		}
 

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -117,7 +117,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 	}
 
-	if cr != nil || len(cr.Chairs) == 0 {
+	if cr == nil || len(cr.Chairs) == 0 {
 		return nil
 	}
 

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -119,7 +119,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 	}
 
-	if len(er.Estates) == 0 {
+	if er == nil || len(er.Estates) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
## 目的

- #91 にて、有効な検索結果が返ってくることを期待して複数回イス・物件検索を行なった
- しかし、有効な検索が一度も行えなかった場合に nil access が発生してしまうことが判明した


## 解決方法

- 有効な検索ができなかった場合には nil access をせずにシナリオを再実行させる


## 動作確認

- [x] 正常に動作することを確認


## 参考文献 (Optional)

- なし
