### PR TITLE
[bench] イス・物件検索のページングの深さに制限をつける

### DIFF
--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -7,6 +7,8 @@ const (
 	NumOfSearchEstateInScenario    = 5
 	NumOfCheckChairSearchPaging    = 3
 	NumOfCheckEstateSearchPaging   = 3
+	LimitOfChairSearchPageDepth    = 5
+	LimitOfEstateSearchPageDepth   = 5
 	NumOfCheckChairDetailPage      = 7
 	NumOfCheckEstateDetailPage     = 3
 	PerPageOfChairSearch           = 30

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -83,6 +83,9 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		if numOfPages == 0 {
 			continue
 		}
+		if numOfPages > parameter.LimitOfChairSearchPageDepth {
+			numOfPages = parameter.LimitOfChairSearchPageDepth
+		}
 
 		for j := 0; j < parameter.NumOfCheckChairSearchPaging; j++ {
 			q.Set("page", strconv.Itoa(rand.Intn(numOfPages)))
@@ -113,6 +116,9 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			numOfPages = int(cr.Count) / parameter.PerPageOfChairSearch
 			if numOfPages == 0 {
 				break
+			}
+			if numOfPages > parameter.LimitOfChairSearchPageDepth {
+				numOfPages = parameter.LimitOfChairSearchPageDepth
 			}
 		}
 	}

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -85,6 +85,9 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		if numOfPages == 0 {
 			continue
 		}
+		if numOfPages > parameter.LimitOfEstateSearchPageDepth {
+			numOfPages = parameter.LimitOfEstateSearchPageDepth
+		}
 
 		for j := 0; j < parameter.NumOfCheckEstateSearchPaging; j++ {
 			q.Set("page", strconv.Itoa(rand.Intn(numOfPages)))
@@ -115,6 +118,9 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			numOfPages = int(er.Count) / parameter.PerPageOfEstateSearch
 			if numOfPages == 0 {
 				break
+			}
+			if numOfPages > parameter.LimitOfEstateSearchPageDepth {
+				numOfPages = parameter.LimitOfEstateSearchPageDepth
 			}
 		}
 	}


### PR DESCRIPTION
## 目的

- イス・物件検索で、 OFFSET の深いところを取得しているためにボトルネック解消が困難になっていた


## 解決方法

- ページの深さに制限を設け、 OFFSET によるボトルネックを緩和する


## 動作確認

- [x] ベンチマークが正常に動作することを確認


## 参考文献 (Optional)

- なし
