### PR TITLE
[webapp/go] Fix range id check

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -628,7 +628,7 @@ func getRange(cond RangeCondition, rangeID string) (*Range, error) {
 		return nil, err
 	}
 
-	if RangeIndex < 0 && len(cond.Ranges) <= RangeIndex {
+	if RangeIndex < 0 || len(cond.Ranges) <= RangeIndex {
 		return nil, fmt.Errorf("Unexpected Range ID")
 	}
 


### PR DESCRIPTION
## 目的

- Go の参考実装において、検索 API に渡された range id の範囲チェックが間違ってそうです


## 解決方法

- getRange() の範囲チェックの条件を修正しました


## 動作確認

- [x] `curl -v 'http://localhost:1323/api/chair/search?heightRangeId=1000&page=1&perPage=1'` が 500 ではなく 400 を返す


## 参考文献 (Optional)

- なし
