### PR TITLE
[webapp/go] Use MYSQL_PORT in POST /initialize

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -294,10 +294,11 @@ func initialize(c echo.Context) error {
 
 	for _, p := range paths {
 		sqlFile, _ := filepath.Abs(p)
-		cmdStr := fmt.Sprintf("mysql -h %v -u %v -p%v %v < %v",
+		cmdStr := fmt.Sprintf("mysql -h %v -u %v -p%v -P %v %v < %v",
 			mySQLConnectionData.Host,
 			mySQLConnectionData.User,
 			mySQLConnectionData.Password,
+			mySQLConnectionData.Port,
 			mySQLConnectionData.DBName,
 			sqlFile,
 		)


### PR DESCRIPTION
## 目的

- Go の参考実装で POST /initialize では MYSQL_PORT の指定が効かない問題を修正します


## 解決方法

- `mySQLConnectionData.Port` を mysql(1) に渡すようにします


## 動作確認


## 参考文献 (Optional)
