### PR TITLE
[webapp/frontend] イス詳細画面から読んでいるAPIのパスを修正

### DIFF
--- a/webapp/frontend/src/pages/chair/detail/index.tsx
+++ b/webapp/frontend/src/pages/chair/detail/index.tsx
@@ -158,7 +158,7 @@ const ChairDetailPage = () => {
       .then(chair => setChair(chair as Chair))
       .catch(error => { throw error })
 
-    fetch(`/api/estate/low_priced/${id.toString()}`, { mode: 'cors' })
+    fetch(`/api/recommended_estate/${id.toString()}`, { mode: 'cors' })
       .then(async response => await response.json())
       .then(json => setLowPricedEstates(json.estates as Estate[]))
       .catch(error => { throw error })


### PR DESCRIPTION
## 目的

- イス詳細画面にて API リクエストに失敗していた
- 本来は `GET /api/recommended_estate/:id` に送るはずだったリクエストを `GET /api/estate/low_priced/:id` に送っていた


## 解決方法

- `GET /api/recommended_estate/:id` にリクエストを送るように修正


## 動作確認

- [x] イス詳細画面が表示できることを確認


## 参考文献 (Optional)

- なし
