### PR TITLE
[webapp/go] Fix wrong error message

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -533,19 +533,19 @@ func searchChairs(c echo.Context) error {
 func buyChair(c echo.Context) error {
 	m := echo.Map{}
 	if err := c.Bind(&m); err != nil {
-		c.Echo().Logger.Infof("post request document failed : %v", err)
+		c.Echo().Logger.Infof("post buy chair failed : %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
 	_, ok := m["email"].(string)
 	if !ok {
-		c.Echo().Logger.Info("post request document failed : email not found in request body")
+		c.Echo().Logger.Info("post buy chair failed : email not found in request body")
 		return c.NoContent(http.StatusBadRequest)
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
-		c.Echo().Logger.Infof("post request document failed : %v", err)
+		c.Echo().Logger.Infof("post buy chair failed : %v", err)
 		return c.NoContent(http.StatusBadRequest)
 	}
 


### PR DESCRIPTION
## 目的

Go 実装における `buyChair()` 内のエラーハンドリングにおけるエラーメッセージがおそらく間違っているので直す


## 解決方法

- `postEstateRequestDocument()` と同じようなフォーマットで `buyChair()` のコンテキストのメッセージに修正した


## 動作確認

- [ ] (動作確認の方法、確認ができたらチェックボックスを埋める)

