### PR TITLE
[bench] イス・物件詳細APIに対してもSnapshot形式のVerifyを行う

### DIFF
--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -83,7 +83,7 @@ func verifyChairDetail(ctx context.Context, c *client.Client, filePath string) e
 		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 
-	id := string([]rune(snapshot.Request.Resource)[idx+1:])
+	id := snapshot.Request.Resource[idx+1:]
 	actual, err := c.GetChairDetailFromID(ctx, id)
 
 	switch snapshot.Response.StatusCode {
@@ -196,7 +196,7 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 
-	id := string([]rune(snapshot.Request.Resource)[idx+1:])
+	id := snapshot.Request.Resource[idx+1:]
 	actual, err := c.GetEstateDetailFromID(ctx, id)
 
 	switch snapshot.Response.StatusCode {
@@ -376,7 +376,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 	if idx == -1 || idx == len(snapshot.Request.Resource)-1 {
 		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
-	id, err := strconv.ParseInt(string([]rune(snapshot.Request.Resource)[idx+1:]), 10, 64)
+	id, err := strconv.ParseInt(snapshot.Request.Resource[idx+1:], 10, 64)
 	if err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -80,7 +80,7 @@ func verifyChairDetail(ctx context.Context, c *client.Client, filePath string) e
 
 	idx := strings.LastIndex(snapshot.Request.Resource, "/")
 	if idx == -1 || idx == len(snapshot.Request.Resource)-1 {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 
 	id := string([]rune(snapshot.Request.Resource)[idx+1:])
@@ -95,7 +95,7 @@ func verifyChairDetail(ctx context.Context, c *client.Client, filePath string) e
 		var expected *asset.Chair
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
@@ -129,7 +129,7 @@ func verifyChairSearchCondition(ctx context.Context, c *client.Client, filePath 
 		var expected *asset.ChairSearchCondition
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search/condition: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search/condition: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
@@ -168,7 +168,7 @@ func verifyChairSearch(ctx context.Context, c *client.Client, filePath string) e
 		var expected *client.ChairsResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
@@ -193,7 +193,7 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 
 	idx := strings.LastIndex(snapshot.Request.Resource, "/")
 	if idx == -1 || idx == len(snapshot.Request.Resource)-1 {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 
 	id := string([]rune(snapshot.Request.Resource)[idx+1:])
@@ -208,7 +208,7 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 		var expected *asset.Estate
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
@@ -242,7 +242,7 @@ func verifyEstateSearchCondition(ctx context.Context, c *client.Client, filePath
 		var expected *asset.EstateSearchCondition
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search/condition: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search/condition: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual) {
@@ -281,7 +281,7 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 		var expected *client.EstatesResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
@@ -315,7 +315,7 @@ func verifyLowPricedChair(ctx context.Context, c *client.Client, filePath string
 		var expected *client.ChairsResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/low_priced: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/low_priced: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreChairUnexported) {
@@ -349,7 +349,7 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 		var expected *client.EstatesResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
@@ -374,11 +374,11 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 
 	idx := strings.LastIndex(snapshot.Request.Resource, "/")
 	if idx == -1 || idx == len(snapshot.Request.Resource)-1 {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 	id, err := strconv.ParseInt(string([]rune(snapshot.Request.Resource)[idx+1:]), 10, 64)
 	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"))
+		return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: 不正なSnapshotです"), failure.Messagef("snapshot: %s", filePath))
 	}
 
 	actual, err := c.GetRecommendedEstatesFromChair(ctx, id)
@@ -392,7 +392,7 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		var expected *client.EstatesResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
 			log.Printf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
@@ -431,7 +431,7 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 		var expected *client.EstatesResponse
 		err = json.Unmarshal([]byte(snapshot.Response.Body), &expected)
 		if err != nil {
-			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: Response BodyのUnmarshalでエラーが発生しました"))
+			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
 		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {

--- a/initial-data/make_verification_data/main.go
+++ b/initial-data/make_verification_data/main.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
+	NumOfChairDetailData                = 100
 	NumOfChairSearchData                = 100
+	NumOfEstateDetailData               = 100
 	NumOfEstateSearchData               = 100
 	NumOfRecommendedEstateWithChairData = 100
 	NumOfEstatesNazotteData             = 100
@@ -89,6 +91,28 @@ func main() {
 
 	MkdirIfNotExists(DestDirectoryPath)
 
+	// chair detail
+	MkdirIfNotExists(filepath.Join(DestDirectoryPath, "chair_detail"))
+	for i := 0; i < NumOfChairDetailData; i++ {
+		wg.Add(1)
+		go func(id int) {
+			req := Request{
+				Method:   "GET",
+				Resource: fmt.Sprintf("/api/chair/%d", id),
+				Query:    "",
+				Body:     "",
+			}
+
+			snapshot := getSnapshotFromRequest(TargetServer, req)
+
+			filename := fmt.Sprintf("%d.json", id)
+			writeSnapshotDataToFile(filepath.Join(DestDirectoryPath, "chair_detail", filename), snapshot)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	log.Println("Done generating verification data of /api/chair/:id")
+
 	// chair search condition
 	MkdirIfNotExists(filepath.Join(DestDirectoryPath, "chair_search_condition"))
 	wg.Add(1)
@@ -128,6 +152,28 @@ func main() {
 	}
 	wg.Wait()
 	log.Println("Done generating verification data of /api/chair/search")
+
+	// estate detail
+	MkdirIfNotExists(filepath.Join(DestDirectoryPath, "estate_detail"))
+	for i := 0; i < NumOfEstateDetailData; i++ {
+		wg.Add(1)
+		go func(id int) {
+			req := Request{
+				Method:   "GET",
+				Resource: fmt.Sprintf("/api/estate/%d", id),
+				Query:    "",
+				Body:     "",
+			}
+
+			snapshot := getSnapshotFromRequest(TargetServer, req)
+
+			filename := fmt.Sprintf("%d.json", id)
+			writeSnapshotDataToFile(filepath.Join(DestDirectoryPath, "estate_detail", filename), snapshot)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	log.Println("Done generating verification data of /api/estate/:id")
 
 	// estate search condition
 	MkdirIfNotExists(filepath.Join(DestDirectoryPath, "estate_search_condition"))


### PR DESCRIPTION
## 目的

- 以前は `view_count` のインクリメントを回避するために以下の API に対する Snapshot 形式の Verify ができなかった
	- `GET /api/chair/:id`
	- `GET /api/estate/:id`
- #82 にて、 `view_count` を廃止してインクリメントがされなくなった

## 解決方法

- イス・物件詳細APIに対してもSnapshot形式のVerifyを行う


## 動作確認

- [x] Verify が通ることを確認


## 参考文献 (Optional)

- なし
