### PR TITLE
[bench] Scenario形式のVerifyでCSV入稿APIを検証する

### DIFF
--- a/bench/asset/condition.go
+++ b/bench/asset/condition.go
@@ -11,10 +11,8 @@ import (
 )
 
 var (
-	chairSearchCondition   *ChairSearchCondition
-	chairFeatureForVerify  *string
-	estateSearchCondition  *EstateSearchCondition
-	estateFeatureForVerify *string
+	chairSearchCondition  *ChairSearchCondition
+	estateSearchCondition *EstateSearchCondition
 )
 
 type Range struct {
@@ -56,12 +54,7 @@ func loadChairSearchCondition(fixtureDir string) error {
 		return err
 	}
 
-	var condition *ChairSearchCondition
-	json.Unmarshal(jsonText, &condition)
-	// condition.Featureの最後の1つはVerify用で該当件数が少ないため、Validationのシナリオ内では使用しない
-	chairFeatureForVerify = &condition.Feature.List[len(condition.Feature.List)-1]
-	condition.Feature.List = condition.Feature.List[:len(condition.Feature.List)-1]
-	chairSearchCondition = condition
+	json.Unmarshal(jsonText, &chairSearchCondition)
 	return nil
 }
 
@@ -70,12 +63,8 @@ func loadEstateSearchCondition(fixtureDir string) error {
 	if err != nil {
 		return err
 	}
-	var condition *EstateSearchCondition
-	json.Unmarshal(jsonText, &condition)
-	// condition.Featureの最後の1つはVerify用で該当件数が少ないため、Validationのシナリオ内では使用しない
-	estateFeatureForVerify = &condition.Feature.List[len(condition.Feature.List)-1]
-	condition.Feature.List = condition.Feature.List[:len(condition.Feature.List)-1]
-	estateSearchCondition = condition
+
+	json.Unmarshal(jsonText, &estateSearchCondition)
 	return nil
 }
 
@@ -86,23 +75,9 @@ func GetChairSearchCondition() (*ChairSearchCondition, error) {
 	return chairSearchCondition, nil
 }
 
-func GetChairFeatureForVerify() (*string, error) {
-	if chairFeatureForVerify == nil {
-		return nil, failure.New(fails.ErrBenchmarker, failure.Message("イスの検索条件が読み込まれていません"))
-	}
-	return chairFeatureForVerify, nil
-}
-
 func GetEstateSearchCondition() (*EstateSearchCondition, error) {
 	if estateSearchCondition == nil {
 		return nil, failure.New(fails.ErrBenchmarker, failure.Message("物件の検索条件が読み込まれていません"))
 	}
 	return estateSearchCondition, nil
-}
-
-func GetEstateFeatureForVerify() (*string, error) {
-	if estateSearchCondition == nil {
-		return nil, failure.New(fails.ErrBenchmarker, failure.Message("物件の検索条件が読み込まれていません"))
-	}
-	return estateFeatureForVerify, nil
 }

--- a/bench/client/webapp.go
+++ b/bench/client/webapp.go
@@ -9,7 +9,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -132,41 +131,11 @@ func (c *Client) GetChairDetailFromID(ctx context.Context, id string) (*asset.Ch
 	return &chair, nil
 }
 
-func loadChairsFromJSON(ctx context.Context, filePath string) ([]asset.Chair, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	chairs := []asset.Chair{}
-	decoder := json.NewDecoder(f)
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		var chair asset.Chair
-		if err := decoder.Decode(&chair); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		chairs = append(chairs, chair)
-	}
-
-	return chairs, nil
-}
-
-func (c *Client) PostChairs(ctx context.Context, filePath string) error {
-	chairs, err := loadChairsFromJSON(ctx, filePath)
-	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker)
-	}
-
+func (c *Client) PostChairs(ctx context.Context, chairs []asset.Chair) error {
 	var (
-		b  bytes.Buffer
-		fw io.Writer
+		b   bytes.Buffer
+		fw  io.Writer
+		err error
 	)
 	w := multipart.NewWriter(&b)
 	csv := ""
@@ -176,7 +145,7 @@ func (c *Client) PostChairs(ctx context.Context, filePath string) error {
 	}
 	r := strings.NewReader(csv)
 
-	if fw, err = w.CreateFormFile("chairs", filePath); err != nil {
+	if fw, err = w.CreateFormFile("chairs", "chairs.csv"); err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 
@@ -466,41 +435,11 @@ func (c *Client) GetEstateDetailFromID(ctx context.Context, id string) (*asset.E
 	return &estate, nil
 }
 
-func loadEstatesFromJSON(ctx context.Context, filePath string) ([]asset.Estate, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	estates := []asset.Estate{}
-	decoder := json.NewDecoder(f)
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		var estate asset.Estate
-		if err := decoder.Decode(&estate); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		estates = append(estates, estate)
-	}
-
-	return estates, nil
-}
-
-func (c *Client) PostEstates(ctx context.Context, filePath string) error {
-	estates, err := loadEstatesFromJSON(ctx, filePath)
-	if err != nil {
-		return failure.Translate(err, fails.ErrBenchmarker)
-	}
-
+func (c *Client) PostEstates(ctx context.Context, estates []asset.Estate) error {
 	var (
-		b  bytes.Buffer
-		fw io.Writer
+		b   bytes.Buffer
+		fw  io.Writer
+		err error
 	)
 	w := multipart.NewWriter(&b)
 	csv := ""
@@ -510,7 +449,7 @@ func (c *Client) PostEstates(ctx context.Context, filePath string) error {
 	}
 	r := strings.NewReader(csv)
 
-	if fw, err = w.CreateFormFile("estates", filePath); err != nil {
+	if fw, err = w.CreateFormFile("estates", "estates.csv"); err != nil {
 		return failure.Translate(err, fails.ErrBenchmarker)
 	}
 

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
@@ -107,7 +106,7 @@ func main() {
 	log.Print("=== verify ===")
 	// 初期チェック：正しく動いているかどうかを確認する
 	// 明らかにおかしいレスポンスを返しているアプリケーションはさっさと停止させることで、運営側のリソースを使い果たさない・他サービスへの攻撃に利用されるを防ぐ
-	scenario.Verify(context.Background(), filepath.Join(dataDir, "result/verification_data"), fixtureDir)
+	scenario.Verify(context.Background(), dataDir, fixtureDir)
 	eMsgs = fails.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("verify failed")

--- a/bench/scenario/chairDraftPostScenario.go
+++ b/bench/scenario/chairDraftPostScenario.go
@@ -2,14 +2,45 @@ package scenario
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
 
+	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/morikuni/failure"
 )
 
+func loadChairsFromJSON(ctx context.Context, filePath string) ([]asset.Chair, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	chairs := []asset.Chair{}
+	decoder := json.NewDecoder(f)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var chair asset.Chair
+		if err := decoder.Decode(&chair); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		chairs = append(chairs, chair)
+	}
+
+	return chairs, nil
+}
+
 func chairDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
-	err := c.PostChairs(ctx, filePath)
+	chairs, err := loadChairsFromJSON(ctx, filePath)
+	err = c.PostChairs(ctx, chairs)
 	if err != nil {
 		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
 	}

--- a/bench/scenario/estateDraftPostScenario.go
+++ b/bench/scenario/estateDraftPostScenario.go
@@ -2,14 +2,45 @@ package scenario
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
 
+	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/morikuni/failure"
 )
 
+func loadEstatesFromJSON(ctx context.Context, filePath string) ([]asset.Estate, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	estates := []asset.Estate{}
+	decoder := json.NewDecoder(f)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var estate asset.Estate
+		if err := decoder.Decode(&estate); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		estates = append(estates, estate)
+	}
+
+	return estates, nil
+}
+
 func estateDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
-	err := c.PostEstates(ctx, filePath)
+	estates, err := loadEstatesFromJSON(ctx, filePath)
+	err = c.PostEstates(ctx, estates)
 	if err != nil {
 		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
 	}

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/morikuni/failure"
@@ -19,7 +18,7 @@ func Verify(ctx context.Context, snapshotsParentsDirPath, fixtureDir string) {
 	verifyWithScenario(ctx, c, fixtureDir)
 }
 
-func verifyChairStock(ctx context.Context, c *client.Client, chairFeatureForVerify string) error {
+func verifyChairStock(ctx context.Context, c *client.Client) error {
 	err := c.BuyChair(ctx, "1")
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -47,16 +46,11 @@ func verifyChairStock(ctx context.Context, c *client.Client, chairFeatureForVeri
 }
 
 func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string) {
-	chairFeatureForVerify, err := asset.GetChairFeatureForVerify()
-	if err != nil {
-		fails.Add(err, fails.ErrorOfVerify)
-	}
-
 	wg := sync.WaitGroup{}
 
 	wg.Add(1)
 	go func() {
-		err := verifyChairStock(ctx, c, *chairFeatureForVerify)
+		err := verifyChairStock(ctx, c)
 		if err != nil {
 			fails.Add(err, fails.ErrorOfVerify)
 		}

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -141,7 +141,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 	})
 
 	if err := eg.Wait(); err != nil {
-		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrBenchmarker), fails.ErrorOfVerify)
+		fails.Add(failure.Translate(err, fails.ErrBenchmarker), fails.ErrorOfVerify)
 		return
 	}
 
@@ -151,7 +151,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 		defer wg.Done()
 		err := verifyPostEstates(ctx, c, estates)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+			fails.Add(err, fails.ErrorOfVerify)
 		}
 	}()
 
@@ -160,7 +160,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 		defer wg.Done()
 		err := verifyPostChairs(ctx, c, chairs)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+			fails.Add(err, fails.ErrorOfVerify)
 		}
 	}()
 

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -2,59 +2,146 @@ package scenario
 
 import (
 	"context"
+	"path"
+	"path/filepath"
+	"strconv"
 	"sync"
 
+	"github.com/isucon10-qualify/isucon10-qualify/bench/asset"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
 	"github.com/morikuni/failure"
+	"golang.org/x/sync/errgroup"
 )
 
 // Verify Initialize後のアプリケーションサーバーに対して、副作用のない検証を実行する
 // 早い段階でベンチマークをFailさせて早期リターンさせるのが目的
 // ex) Search API を叩いて初期状態を確認する
-func Verify(ctx context.Context, snapshotsParentsDirPath, fixtureDir string) {
+func Verify(ctx context.Context, dataDir, fixtureDir string) {
 	c := client.NewClientForVerify()
-	verifyWithSnapshot(ctx, c, snapshotsParentsDirPath)
-	verifyWithScenario(ctx, c, fixtureDir)
+	verifyWithSnapshot(ctx, c, filepath.Join(dataDir, "result/verification_data"))
+	verifyWithScenario(ctx, c, fixtureDir, dataDir)
 }
 
-func verifyChairStock(ctx context.Context, c *client.Client) error {
-	err := c.BuyChair(ctx, "1")
+func verifyPostEstates(ctx context.Context, c *client.Client, estates []asset.Estate) error {
+	err := c.PostEstates(ctx, estates)
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		return failure.Translate(err, fails.ErrApplication)
+		return err
 	}
 
-	chair, err := c.GetChairDetailFromID(ctx, "1")
+	return nil
+}
+
+func verifyPostChairs(ctx context.Context, c *client.Client, chairs []asset.Chair) error {
+	err := c.PostChairs(ctx, chairs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyChairStock(ctx context.Context, c *client.Client, id int64) error {
+	strID := strconv.FormatInt(id, 10)
+
+	chair, err := c.GetChairDetailFromID(ctx, strID)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		return failure.Translate(err, fails.ErrApplication)
+		return failure.Translate(err, fails.ErrApplication, failure.Message("イスの詳細取得に失敗しました"))
+	}
+	if chair == nil {
+		return failure.New(fails.ErrApplication, failure.Message("在庫のあるはずのイスが売り切れになっています"))
+	}
+
+	err = c.BuyChair(ctx, strID)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return failure.Translate(err, fails.ErrApplication, failure.Message("イスの購入に失敗しました"))
+	}
+
+	chair, err = c.GetChairDetailFromID(ctx, strID)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return failure.Translate(err, fails.ErrApplication, failure.Message("売り切れたイスが存在します"))
 	}
 
 	if chair != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		return failure.New(fails.ErrApplication, failure.Message("イスの在庫数が不正です"))
+		return failure.New(fails.ErrApplication, failure.Message("売り切れたイスの詳細が表示されています"))
 	}
 
 	return nil
 }
 
-func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string) {
+func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snapshotsParentsDirPath string) {
+	var (
+		estates []asset.Estate
+		chairs  []asset.Chair
+	)
+
+	eg, childCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		var err error
+		estates, err = loadEstatesFromJSON(childCtx, path.Join(snapshotsParentsDirPath, "result/verify_draft_estate.txt"))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	eg.Go(func() error {
+		var err error
+		chairs, err = loadChairsFromJSON(childCtx, path.Join(snapshotsParentsDirPath, "result/verify_draft_chair.txt"))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrBenchmarker), fails.ErrorOfVerify)
+		return
+	}
+
 	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := verifyPostEstates(ctx, c, estates)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		}
+	}()
 
 	wg.Add(1)
 	go func() {
-		err := verifyChairStock(ctx, c)
+		defer wg.Done()
+		err := verifyPostChairs(ctx, c, chairs)
+		if err != nil {
+			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		}
+	}()
+
+	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := verifyChairStock(ctx, c, chairs[0].ID)
 		if err != nil {
 			fails.Add(err, fails.ErrorOfVerify)
 		}
-		wg.Done()
 	}()
 
 	wg.Wait()

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -24,10 +24,10 @@ import (
 
 const (
 	NumOfVerifyChairDetail                = 5
-	NumOfVerifyChairSearchCondition       = 5
+	NumOfVerifyChairSearchCondition       = 1
 	NumOfVerifyChairSearch                = 5
 	NumOfVerifyEstateDetail               = 5
-	NumOfVerifyEstateSearchCondition      = 5
+	NumOfVerifyEstateSearchCondition      = 1
 	NumOfVerifyEstateSearch               = 5
 	NumOfVerifyLowPricedChair             = 1
 	NumOfVerifyLowPricedEstate            = 1

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -20,8 +20,8 @@ RECORD_COUNT = (10 ** 4) * 3
 BULK_INSERT_COUNT = 500
 CHAIR_MIN_CENTIMETER = 30
 CHAIR_MAX_CENTIMETER = 200
-MIN_VIEW_COUNT = 3000
-MAX_VIEW_COUNT = 1000000
+MIN_POPULARITY = 3000
+MAX_POPULARITY = 1000000
 HEIGHT_RANGE_SEPARATORS = [80, 110, 150]
 WIDTH_RANGE_SEPARATORS = [80, 110, 150]
 DEPTH_RANGE_SEPARATORS = [80, 110, 150]
@@ -208,7 +208,7 @@ def generate_chair_dummy_data(chair_id, wrap={}):
         "width": random.randint(CHAIR_MIN_CENTIMETER, CHAIR_MAX_CENTIMETER),
         "depth": random.randint(CHAIR_MIN_CENTIMETER, CHAIR_MAX_CENTIMETER),
         "color": fake.word(ext_word_list=CHAIR_COLOR_LIST),
-        "popularity": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
+        "popularity": random.randint(MIN_POPULARITY, MAX_POPULARITY),
         "stock": random.randint(1, 10),
         "description": random.choice(desc_lines).strip(),
         "features": ",".join(fake.words(nb=features_length, ext_word_list=CHAIR_FEATURE_LIST, unique=True)),

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -153,11 +153,11 @@ CHAIR_IMAGE_HASH_LIST = [fake.sha256(
     raw_output=False) for _ in range(CHAIR_DUMMY_IMAGE_NUM)]
 
 
-def generate_ranges_from_SEPARATORS(SEPARATORSs):
+def generate_ranges_from_SEPARATORS(separators):
     before = -1
     ranges = []
 
-    for i, SEPARATORS in enumerate(SEPARATORSs + [-1]):
+    for i, SEPARATORS in enumerate(separators + [-1]):
         ranges.append({
             "id": i,
             "min": before,

--- a/initial-data/make_chair_data.py
+++ b/initial-data/make_chair_data.py
@@ -139,9 +139,8 @@ CHAIR_FEATURE_LIST = [
     "アームなし",
     "オーダーメイド可能",
     "ポリカーボネート製",
+    "フットレスト付き",
 ]
-
-CHAIR_FEATURE_FOR_VERIFY = "フットレスト付き"
 
 CHAIR_KIND_LIST = [
     "ゲーミングチェア",
@@ -239,21 +238,7 @@ if __name__ == "__main__":
 
         CHAIRS_FOR_VERIFY = [
             # 購入された際に在庫が減ることを検証するためのデータ
-            generate_chair_dummy_data(1, {
-                "features": CHAIR_FEATURE_FOR_VERIFY,
-                "stock": 1,
-                "popularity": MIN_VIEW_COUNT
-            }),
-            # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (2位 → 1位)
-            generate_chair_dummy_data(2, {
-                "features": CHAIR_FEATURE_FOR_VERIFY,
-                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
-            }),
-            # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (1位 → 2位)
-            generate_chair_dummy_data(3, {
-                "features": CHAIR_FEATURE_FOR_VERIFY,
-                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
-            })
+            generate_chair_dummy_data(1, {"stock": 1}),
         ]
 
         sqlCommand = f"""INSERT INTO isuumo.chair (id, thumbnail, name, price, height, width, depth, popularity, stock, color, description, features, kind) VALUES {", ".join(map(lambda chair: f"('{chair['id']}', '{chair['thumbnail']}', '{chair['name']}', '{chair['price']}', '{chair['height']}', '{chair['width']}', '{chair['depth']}', '{chair['popularity']}', '{chair['stock']}', '{chair['color']}', '{chair['description']}', '{chair['features']}', '{chair['kind']}')", CHAIRS_FOR_VERIFY))};"""
@@ -307,7 +292,7 @@ if __name__ == "__main__":
                 "list": CHAIR_COLOR_LIST
             },
             "feature": {
-                "list": CHAIR_FEATURE_LIST + [CHAIR_FEATURE_FOR_VERIFY]
+                "list": CHAIR_FEATURE_LIST
             },
             "kind": {
                 "list": CHAIR_KIND_LIST

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -23,8 +23,8 @@ DOOR_MAX_CENTIMETER = 200
 DOOR_HEIGHT_RANGE_SEPARATORS = [80, 110, 150]
 DOOR_WIDTH_RANGE_SEPARATORS = [80, 110, 150]
 RENT_RANGE_SEPARATORS = [50000, 100000, 150000]
-MIN_VIEW_COUNT = 3000
-MAX_VIEW_COUNT = 1000000
+MIN_POPULARITY = 3000
+MAX_POPULARITY = 1000000
 DRAFT_COUNT_PER_FILE = 500
 DRAFT_FILE_COUNT = 20
 
@@ -147,7 +147,7 @@ def generate_estate_dummy_data(estate_id, wrap={}):
         "rent": random.randint(30000, 200000),
         "door_height": random.randint(DOOR_MIN_CENTIMETER, DOOR_MAX_CENTIMETER),
         "door_width": random.randint(DOOR_MIN_CENTIMETER, DOOR_MAX_CENTIMETER),
-        "popularity": random.randint(MIN_VIEW_COUNT, MAX_VIEW_COUNT),
+        "popularity": random.randint(MIN_POPULARITY, MAX_POPULARITY),
         "description": random.choice(desc_lines).strip(),
         "features": ','.join(fake.words(nb=feature_length, ext_word_list=ESTATE_FEATURE_LIST, unique=True))
     }

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -173,26 +173,6 @@ if __name__ == '__main__':
             raise Exception("The results of RECORD_COUNT and BULK_INSERT_COUNT need to be a divisible number. RECORD_COUNT = {}, BULK_INSERT_COUNT = {}".format(
                 RECORD_COUNT, BULK_INSERT_COUNT))
 
-        ESTATES_FOR_VERIFY = [
-            # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (2位 → 1位)
-            generate_estate_dummy_data(1, {
-                "features": ESTATE_FEATURE_FOR_VERIFY,
-                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2
-            }),
-            # 2回閲覧された後の検索で、順番が前に行くことを検証するためのデータ (1位 → 2位)
-            generate_estate_dummy_data(2, {
-                "features": ESTATE_FEATURE_FOR_VERIFY,
-                "popularity": (MAX_VIEW_COUNT + MIN_VIEW_COUNT) // 2 + 1
-            })
-        ]
-
-        sqlCommand = f"""INSERT INTO isuumo.estate (id, thumbnail, name, latitude, longitude, address, rent, door_height, door_width, popularity, description, features) VALUES {', '.join(map(lambda estate: f"('{estate['id']}', '{estate['thumbnail']}', '{estate['name']}', '{estate['latitude']}' , '{estate['longitude']}', '{estate['address']}', '{estate['rent']}', '{estate['door_height']}', '{estate['door_width']}', '{estate['popularity']}', '{estate['description']}', '{estate['features']}')", ESTATES_FOR_VERIFY))};"""
-        sqlfile.write(sqlCommand)
-        txtfile.write("\n".join([dump_estate_to_json_str(estate)
-                                 for estate in ESTATES_FOR_VERIFY]) + "\n")
-
-        estate_id += len(ESTATES_FOR_VERIFY)
-
         for _ in range(RECORD_COUNT//BULK_INSERT_COUNT):
             bulk_list = [generate_estate_dummy_data(
                 estate_id + i) for i in range(BULK_INSERT_COUNT)]
@@ -228,6 +208,6 @@ if __name__ == '__main__':
                 "ranges": generate_ranges_from_separator(RENT_RANGE_SEPARATORS)
             },
             "feature": {
-                "list": ESTATE_FEATURE_LIST + [ESTATE_FEATURE_FOR_VERIFY]
+                "list": ESTATE_FEATURE_LIST
             }
         }, ensure_ascii=False, indent=2))

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -88,10 +88,9 @@ ESTATE_FEATURE_LIST = [
     "楽器相談可",
     "フローリング",
     "オール電化",
-    "TVモニタ付きインタホン"
+    "TVモニタ付きインタホン",
+    "デザイナーズ物件"
 ]
-
-ESTATE_FEATURE_FOR_VERIFY = "デザイナーズ物件"
 
 ESTATE_IMAGE_HASH_LIST = [fake.sha256(
     raw_output=False) for _ in range(ESTATE_DUMMY_IMAGE_NUM)]

--- a/initial-data/make_estate_data.py
+++ b/initial-data/make_estate_data.py
@@ -11,12 +11,13 @@ random.seed(19700101)
 DESCRIPTION_LINES_FILE = "./description.txt"
 OUTPUT_SQL_FILE = "./result/1_DummyEstateData.sql"
 OUTPUT_TXT_FILE = "./result/estate_json.txt"
+VERIFY_DRAFT_FILE = "./result/verify_draft_estate.txt"
 OUTPUT_DRAFT_FILE = "./result/draft_data/estate/{index}.txt"
 OUTPUT_FIXTURE_FILE = "./result/estate_condition.json"
 ESTATE_IMAGE_ORIGIN_DIR = "./origin/estate"
 ESTATE_IMAGE_PUBLIC_DIR = "../webapp/frontend/public/images/estate"
 ESTATE_DUMMY_IMAGE_NUM = 1000
-RECORD_COUNT = (10 ** 4) * 3
+RECORD_COUNT = (10 ** 4) * 3 - 500
 BULK_INSERT_COUNT = 500
 DOOR_MIN_CENTIMETER = 30
 DOOR_MAX_CENTIMETER = 200
@@ -25,6 +26,7 @@ DOOR_WIDTH_RANGE_SEPARATORS = [80, 110, 150]
 RENT_RANGE_SEPARATORS = [50000, 100000, 150000]
 MIN_POPULARITY = 3000
 MAX_POPULARITY = 1000000
+VERIFY_DRAFT_COUNT = 500
 DRAFT_COUNT_PER_FILE = 500
 DRAFT_FILE_COUNT = 20
 
@@ -181,6 +183,13 @@ if __name__ == '__main__':
             sqlfile.write(sqlCommand)
             txtfile.write("\n".join([dump_estate_to_json_str(estate)
                                      for estate in bulk_list]) + "\n")
+
+    with open(VERIFY_DRAFT_FILE, mode='w', encoding='utf-8') as verify_draft_file:
+        verify_draft_estates = [generate_estate_dummy_data(
+            estate_id + i) for i in range(VERIFY_DRAFT_COUNT)]
+        estate_id += VERIFY_DRAFT_COUNT
+        verify_draft_file.write(
+            "\n".join([dump_estate_to_json_str(estate) for estate in verify_draft_estates]) + "\n")
 
     for i in range(DRAFT_FILE_COUNT):
         with open(OUTPUT_DRAFT_FILE.format(index=i), mode='w', encoding='utf-8') as draft_file:


### PR DESCRIPTION
## 目的

- Validation 以前に CSV 入稿が正しく動作するか検証していなかった
- もし、 CSV 入稿を拒否する作りにした場合、データを増やさないままでのベンチマークを容易に実現できてしまう


## 解決方法

- Scenario形式のVerifyでCSV入稿APIを検証する


## 動作確認

- [x] ベンチマークが正常に動作することを確認
- [x] 初期実装でのベンチマークにて発生する I/O wait が大きすぎないことを確認


## 参考文献 (Optional)

- なし
