### PR TITLE
[bench] checkに失敗した際に内部的に理由をエラーメッセージとして出す

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -22,14 +22,14 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
+	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
+	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -72,8 +72,8 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			continue
 		}
 
-		if !isChairsOrderedByPopularity(_cr.Chairs, t) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
+		if err := checkChairsOrderedByPopularity(_cr.Chairs, t); err != nil {
+			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -106,8 +106,8 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isChairsOrderedByPopularity(cr.Chairs, t) {
-				err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
+			if err := checkChairsOrderedByPopularity(cr.Chairs, t); err != nil {
+				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
@@ -150,14 +150,14 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			return nil
 		}
 
-		if !isChairEqualToAsset(chair) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
+		if err := checkChairEqualToAsset(chair); err != nil {
+			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
-		if !isEstatesOrderedByPopularity(er.Estates) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
+		if err := checkEstatesOrderedByPopularity(er.Estates); err != nil {
+			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -192,8 +192,8 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			return failure.New(fails.ErrTimeout)
 		}
 
-		if !isEstateEqualToAsset(e) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
+		if err := checkEstateEqualToAsset(e); err != nil {
+			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -178,14 +178,14 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
+	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
+	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -227,8 +227,8 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isEstatesInBoundingBox(er.Estates, boundingBox) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/nazotte: レスポンスの内容が不正です"))
+	if err := checkEstatesInBoundingBox(er.Estates, boundingBox); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/nazotte: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -23,14 +23,14 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isChairsOrderedByPrice(chairs.Chairs, t) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
+	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
-	if !isEstatesOrderedByRent(estates.Estates) {
-		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
+	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
+		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
 		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
@@ -73,8 +73,8 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			continue
 		}
 
-		if !isEstatesOrderedByPopularity(_er.Estates) {
-			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
+		if err := checkEstatesOrderedByPopularity(_er.Estates); err != nil {
+			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
@@ -108,8 +108,8 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if !isEstatesOrderedByPopularity(er.Estates) {
-				err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
+			if err := checkEstatesOrderedByPopularity(er.Estates); err != nil {
+				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
 				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}


### PR DESCRIPTION
## 目的

- レスポンスの check に失敗した際の理由がわかりづらく、修正が難しかった


## 解決方法

- なぜ check に失敗したかを内部的に表示する


## 動作確認

- [x] ベンチマークが正常に動作することを確認
- [x] 失敗した理由が表示されることを確認


## 参考文献 (Optional)

- なし
