### PR TITLE
[bench] エラー発生の有無にかかわらず点数でレベルアップさせる

### DIFF
--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log"
 	"sync"
-	"time"
 
 	"github.com/morikuni/failure"
 )
@@ -51,8 +50,7 @@ func init() {
 }
 
 type Errors struct {
-	Msgs           []string
-	lastErrorTimes map[ErrorLabel]time.Time
+	Msgs []string
 
 	critical    int
 	application int
@@ -63,17 +61,9 @@ type Errors struct {
 
 func NewErrors() *Errors {
 	msgs := make([]string, 0, 100)
-	times := make(map[ErrorLabel]time.Time)
 	return &Errors{
-		Msgs:           msgs,
-		lastErrorTimes: times,
+		Msgs: msgs,
 	}
-}
-
-func (e *Errors) GetLastErrorTime(label ErrorLabel) time.Time {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-	return e.lastErrorTimes[label]
 }
 
 func (e *Errors) GetMsgs() (msgs []string) {
@@ -104,8 +94,6 @@ func (e *Errors) Add(err error, label ErrorLabel) {
 	defer e.mu.Unlock()
 
 	log.Printf("%+v", err)
-
-	e.lastErrorTimes[label] = time.Now()
 
 	msg, ok := failure.MessageOf(err)
 	code, _ := failure.CodeOf(err)

--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -22,7 +22,6 @@ const (
 	SleepSwingOnBotInterval        = 100 // * time.Millisecond
 	SleepBeforePostDraft           = 500 * time.Millisecond
 	SleepSwingBeforePostDraft      = 100 // * time.Millisecond
-	IntervalForCheckWorkers        = 5 * time.Second
 	ThresholdTimeOfAbandonmentPage = 1000 * time.Millisecond
 	DefaultAPITimeout              = 2000 * time.Millisecond
 	InitializeTimeout              = 30 * time.Second

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -178,34 +178,25 @@ func checkWorkers(ctx context.Context) {
 	for {
 		select {
 		case level := <-score.LevelUp():
-			cet := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfChairSearchScenario)
-			eet := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfEstateSearchScenario)
-			net := fails.ErrorsForCheck.GetLastErrorTime(fails.ErrorOfEstateNazotteSearchScenario)
-			if time.Since(cet) > parameter.IntervalForCheckWorkers &&
-				time.Since(eet) > parameter.IntervalForCheckWorkers &&
-				time.Since(net) > parameter.IntervalForCheckWorkers {
-				log.Println("負荷レベルが上昇しました。")
-				incWorkers := parameter.ListOfIncWorkers[level]
-				for i := 0; i < incWorkers.ChairSearchWorker; i++ {
-					go runChairSearchWorker(ctx)
-				}
-				for i := 0; i < incWorkers.EstateSearchWorker; i++ {
-					go runEstateSearchWorker(ctx)
-				}
-				for i := 0; i < incWorkers.EstateNazotteSearchWorker; i++ {
-					go runEstateNazotteSearchWorker(ctx)
-				}
-				for i := 0; i < incWorkers.BotWorker; i++ {
-					go runBotWorker(ctx)
-				}
-				for i := 0; i < incWorkers.ChairDraftPostWorker; i++ {
-					go runChairDraftPostWorker(ctx)
-				}
-				for i := 0; i < incWorkers.EstateDraftPostWorker; i++ {
-					go runEstateDraftPostWorker(ctx)
-				}
-			} else {
-				log.Println("シナリオ内でエラーが発生したため負荷レベルを上げられませんでした。")
+			log.Println("負荷レベルが上昇しました。")
+			incWorkers := parameter.ListOfIncWorkers[level]
+			for i := 0; i < incWorkers.ChairSearchWorker; i++ {
+				go runChairSearchWorker(ctx)
+			}
+			for i := 0; i < incWorkers.EstateSearchWorker; i++ {
+				go runEstateSearchWorker(ctx)
+			}
+			for i := 0; i < incWorkers.EstateNazotteSearchWorker; i++ {
+				go runEstateNazotteSearchWorker(ctx)
+			}
+			for i := 0; i < incWorkers.BotWorker; i++ {
+				go runBotWorker(ctx)
+			}
+			for i := 0; i < incWorkers.ChairDraftPostWorker; i++ {
+				go runChairDraftPostWorker(ctx)
+			}
+			for i := 0; i < incWorkers.EstateDraftPostWorker; i++ {
+				go runEstateDraftPostWorker(ctx)
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## 目的

- レベルアップ目前でエラーが発生してしまうと、レベルアップの点数に達しても負荷が上昇しない


## 解決方法

- エラー発生の有無にかかわらず点数でレベルアップさせる


## 動作確認

- [x] レベルアップすることを確認


## 参考文献 (Optional)

- なし
