### PR TITLE
[bench] 入稿時にエラーが起きたらfailさせる

### DIFF
--- a/bench/scenario/chairDraftPostScenario.go
+++ b/bench/scenario/chairDraftPostScenario.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
+	"github.com/morikuni/failure"
 )
 
 func chairDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	err := c.PostChairs(ctx, filePath)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairDraftPostScenario)
+		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
 	}
 }

--- a/bench/scenario/estateDraftPostScenario.go
+++ b/bench/scenario/estateDraftPostScenario.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
+	"github.com/morikuni/failure"
 )
 
 func estateDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	err := c.PostEstates(ctx, filePath)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateDraftPostScenario)
+		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
 	}
 }


### PR DESCRIPTION
## 目的

- CSV 入稿に対して、エラーを返すことで件数を増やさないというハックができてしまう


## 解決方法

- CSV 入稿に失敗した場合は fail させる


## 動作確認

- [x] CSV 入稿に失敗すると fail することを確認


## 参考文献 (Optional)

- なし
