### PR TITLE
[bench] Errorsを消し、fails packageで一元管理するように変更

### DIFF
--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -113,7 +113,7 @@ func Initialize(ctx context.Context, dataDir, fixtureDir string) {
 
 	if err := eg.Wait(); err != nil {
 		err = failure.Translate(err, fails.ErrBenchmarker, failure.Message("assetの初期化に失敗しました"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfInitialize)
+		fails.Add(err, fails.ErrorOfInitialize)
 	}
 }
 

--- a/bench/client/browse.go
+++ b/bench/client/browse.go
@@ -44,7 +44,7 @@ func (c *Client) AccessChairDetailPage(ctx context.Context, id int64) (*asset.Ch
 	eg, childCtx := errgroup.WithContext(ctx)
 
 	var (
-		chair *asset.Chair
+		chair   *asset.Chair
 		estates *EstatesResponse
 	)
 

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -71,7 +71,7 @@ func main() {
 
 	// 初期データの準備
 	asset.Initialize(context.Background(), dataDir, fixtureDir)
-	eMsgs := fails.ErrorsForCheck.GetMsgs()
+	eMsgs := fails.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("asset initialize failed")
 
@@ -89,7 +89,7 @@ func main() {
 	log.Print("=== initialize ===")
 	// 初期化：/initialize にリクエストを送ることで、外部リソースのURLを指定する・DBのデータを初期データのみにする
 	initRes := scenario.Initialize(context.Background())
-	eMsgs = fails.ErrorsForCheck.GetMsgs()
+	eMsgs = fails.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("initialize failed")
 
@@ -108,7 +108,7 @@ func main() {
 	// 初期チェック：正しく動いているかどうかを確認する
 	// 明らかにおかしいレスポンスを返しているアプリケーションはさっさと停止させることで、運営側のリソースを使い果たさない・他サービスへの攻撃に利用されるを防ぐ
 	scenario.Verify(context.Background(), filepath.Join(dataDir, "result/verification_data"), fixtureDir)
-	eMsgs = fails.ErrorsForCheck.GetMsgs()
+	eMsgs = fails.GetMsgs()
 	if len(eMsgs) > 0 {
 		log.Print("verify failed")
 		output := Output{
@@ -132,7 +132,7 @@ func main() {
 	log.Printf("最終的な負荷レベル: %d", score.GetLevel())
 
 	// context.Canceledのエラーは直後に取れば基本的には入ってこない
-	eMsgs, cCnt, aCnt, _ := fails.ErrorsForCheck.Get()
+	eMsgs, cCnt, aCnt, _ := fails.Get()
 	// critical errorは1つでもあれば、application errorは10回以上で失格
 	if cCnt > 0 || aCnt >= 10 {
 		log.Print("cause error!")

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -18,14 +18,14 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q, err := createRandomChairSearchQuery()
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			fails.Add(err, fails.ErrorOfBotScenario)
 		}
 		q.Set("perPage", "10")
 		chairs, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+				fails.Add(err, fails.ErrorOfBotScenario)
 			}
 			return
 		}
@@ -37,7 +37,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 				_, err := c.GetChairDetailFromID(ctx, id)
 				code, _ := failure.CodeOf(err)
 				if code != fails.ErrBot {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+					fails.Add(err, fails.ErrorOfBotScenario)
 				}
 			}(strconv.FormatInt(chair.ID, 10))
 		}
@@ -48,7 +48,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q, err := createRandomEstateSearchQuery()
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+			fails.Add(err, fails.ErrorOfBotScenario)
 		}
 		q.Set("perPage", "10")
 
@@ -56,7 +56,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+				fails.Add(err, fails.ErrorOfBotScenario)
 			}
 			return
 		}
@@ -68,7 +68,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 				_, err := c.GetEstateDetailFromID(ctx, id)
 				code, _ := failure.CodeOf(err)
 				if code != fails.ErrBot {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfBotScenario)
+					fails.Add(err, fails.ErrorOfBotScenario)
 				}
 			}(strconv.FormatInt(estate.ID, 10))
 		}

--- a/bench/scenario/chairDraftPostScenario.go
+++ b/bench/scenario/chairDraftPostScenario.go
@@ -11,6 +11,6 @@ import (
 func chairDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	err := c.PostChairs(ctx, filePath)
 	if err != nil {
-		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
 	}
 }

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -18,19 +18,19 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -41,7 +41,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessChairSearchPage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -53,14 +53,14 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	for i := 0; i < parameter.NumOfSearchChairInScenario; i++ {
 		q, err := createRandomChairSearchQuery()
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
 		t = time.Now()
 		_cr, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -74,7 +74,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkChairsOrderedByPopularity(_cr.Chairs, t); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -93,7 +93,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			t := time.Now()
 			_cr, err := c.SearchChairsWithQuery(ctx, q)
 			if err != nil {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -102,13 +102,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if len(_cr.Chairs) == 0 {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
 			if err := checkChairsOrderedByPopularity(cr.Chairs, t); err != nil {
 				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -138,7 +138,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		chair, er, err = c.AccessChairDetailPage(ctx, targetID)
 
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -152,13 +152,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkChairEqualToAsset(chair); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
 		if err := checkEstatesOrderedByPopularity(er.Estates); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -171,7 +171,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.BuyChair(ctx, strconv.FormatInt(targetID, 10))
 	if err != nil {
 		if _chair, err := asset.GetChairFromID(targetID); err != nil || _chair.GetStock() > 0 {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -184,7 +184,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		t = time.Now()
 		e, err := c.AccessEstateDetailPage(ctx, targetID)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -194,7 +194,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkEstateEqualToAsset(e); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err, fails.ErrorOfChairSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -207,7 +207,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err, fails.ErrorOfChairSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/estateDraftPostScenario.go
+++ b/bench/scenario/estateDraftPostScenario.go
@@ -11,6 +11,6 @@ import (
 func estateDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	err := c.PostEstates(ctx, filePath)
 	if err != nil {
-		fails.ErrorsForCheck.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
 	}
 }

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -174,19 +174,19 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -197,7 +197,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessEstateNazottePage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -213,7 +213,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	er, err := c.SearchEstatesNazotte(ctx, polygon)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -223,13 +223,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 
 	if len(er.Estates) > parameter.MaxLengthOfNazotteResponse {
 		err = failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesInBoundingBox(er.Estates, boundingBox); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/nazotte: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -242,7 +242,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	e, err := c.AccessEstateDetailPage(ctx, targetID)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -253,13 +253,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	estate, err := asset.GetEstateFromID(e.ID)
 	if err != nil || !e.Equal(estate) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -19,19 +19,19 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -42,7 +42,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessEstateSearchPage(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -54,14 +54,14 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	for i := 0; i < parameter.NumOfSearchEstateInScenario; i++ {
 		q, err := createRandomEstateSearchQuery()
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
 		t = time.Now()
 		_er, err := c.SearchEstatesWithQuery(ctx, q)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -75,7 +75,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkEstatesOrderedByPopularity(_er.Estates); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -95,7 +95,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			t := time.Now()
 			_er, err := c.SearchEstatesWithQuery(ctx, q)
 			if err != nil {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -104,13 +104,13 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if len(_er.Estates) == 0 {
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
 			if err := checkEstatesOrderedByPopularity(er.Estates); err != nil {
 				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
-				fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err, fails.ErrorOfEstateSearchScenario)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -137,7 +137,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		t = time.Now()
 		e, err := c.AccessEstateDetailPage(ctx, targetID)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -148,7 +148,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		estate, err := asset.GetEstateFromID(e.ID)
 		if err != nil || !e.Equal(estate) {
 			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err, fails.ErrorOfEstateSearchScenario)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -160,7 +160,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err, fails.ErrorOfEstateSearchScenario)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -18,7 +18,7 @@ func Initialize(ctx context.Context) *client.InitializeResponse {
 
 	res, err := initialize(ctx)
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfInitialize)
+		fails.Add(err, fails.ErrorOfInitialize)
 	}
 	return res
 }

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -49,7 +49,7 @@ func verifyChairStock(ctx context.Context, c *client.Client, chairFeatureForVeri
 func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string) {
 	chairFeatureForVerify, err := asset.GetChairFeatureForVerify()
 	if err != nil {
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	}
 
 	wg := sync.WaitGroup{}
@@ -58,7 +58,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir string
 	go func() {
 		err := verifyChairStock(ctx, c, *chairFeatureForVerify)
 		if err != nil {
-			fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+			fails.Add(err, fails.ErrorOfVerify)
 		}
 		wg.Done()
 	}()

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -455,7 +455,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err := ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyChairDetail; i++ {
 			wg.Add(1)
@@ -463,7 +463,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairDetail(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -474,7 +474,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search/condition: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyChairSearchCondition; i++ {
 			wg.Add(1)
@@ -482,7 +482,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairSearchCondition(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -493,7 +493,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyChairSearch; i++ {
 			wg.Add(1)
@@ -501,7 +501,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairSearch(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -512,7 +512,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyEstateDetail; i++ {
 			wg.Add(1)
@@ -520,7 +520,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateDetail(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -531,7 +531,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search/condition: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyEstateSearchCondition; i++ {
 			wg.Add(1)
@@ -539,7 +539,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateSearchCondition(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -550,7 +550,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyEstateSearch; i++ {
 			wg.Add(1)
@@ -558,7 +558,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateSearch(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -569,7 +569,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/low_priced: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyLowPricedChair; i++ {
 			wg.Add(1)
@@ -577,7 +577,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyLowPricedChair(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -588,7 +588,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyLowPricedEstate; i++ {
 			wg.Add(1)
@@ -596,7 +596,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyLowPricedEstate(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -607,7 +607,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyRecommendedEstateWithChair; i++ {
 			wg.Add(1)
@@ -615,7 +615,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyRecommendedEstateWithChair(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -626,7 +626,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: Snapshotディレクトリがありません"))
-		fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+		fails.Add(err, fails.ErrorOfVerify)
 	} else {
 		for i := 0; i < NumOfVerifyEstateNazotte; i++ {
 			wg.Add(1)
@@ -634,7 +634,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateNazotte(ctx, c, filePath)
 				if err != nil {
-					fails.ErrorsForCheck.Add(err, fails.ErrorOfVerify)
+					fails.Add(err, fails.ErrorOfVerify)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))


### PR DESCRIPTION
## 目的

- `fails` package は `ErrorForCheck` と `ErrorForFinal` という二つの `Errors` struct を持っていた
- これは github.com/isucon/isucon9-qualify に習ってのものだった
- しかし、今回の問題では `ErrorForFinal` は使用する機会がなく、 `ErrorForCheck` だけで管理を行っていた


## 解決方法

- `Errors` を消し、 `fails` packageで一元管理するように変更


## 動作確認

- [x] ベンチマークが正常に終了することを確認


## 参考文献 (Optional)

- なし
