### PR TITLE
[bench] fail条件が達成されたら即座にfailさせる

### DIFF
--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -54,7 +54,7 @@ func init() {
 	failChan = make(chan bool, 1)
 }
 
-func GetMsgs() (msgs []string) {
+func GetMsgs() ([]string) {
 	mu.RLock()
 	defer mu.RUnlock()
 

--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -113,7 +113,6 @@ func Add(err error, label ErrorLabel) {
 	}
 
 	if critical > 0 || application >= 10 {
-		log.Printf("%v, %v", critical, application)
 		failChan <- true
 	}
 }

--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -44,11 +44,14 @@ var (
 	application int
 	trivial     int
 
+	failChan chan bool
+
 	mu sync.RWMutex
 )
 
 func init() {
 	msgs = make([]string, 0, 100)
+	failChan = make(chan bool, 1)
 }
 
 func GetMsgs() (msgs []string) {
@@ -58,10 +61,9 @@ func GetMsgs() (msgs []string) {
 	return msgs[:]
 }
 
-func Get() (msgs []string, critical, application, trivial int) {
+func Get() ([]string, int, int, int) {
 	mu.RLock()
 	defer mu.RUnlock()
-
 	return msgs[:], critical, application, trivial
 }
 
@@ -109,4 +111,13 @@ func Add(err error, label ErrorLabel) {
 		critical++
 		msgs = append(msgs, "運営に連絡してください")
 	}
+
+	if critical > 0 || application >= 10 {
+		log.Printf("%v, %v", critical, application)
+		failChan <- true
+	}
+}
+
+func Fail() chan bool {
+	return failChan
 }

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -123,6 +123,8 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		}
 	}
 
+	fails.Add(failure.New(fails.ErrCritical, failure.Message("qwertyuiop")), fails.ErrorOfChairSearchScenario)
+
 	if cr == nil || len(cr.Chairs) == 0 {
 		return nil
 	}

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -27,5 +27,9 @@ func Validation(ctx context.Context) {
 	cancelCtx, cancel := context.WithTimeout(ctx, parameter.LoadTimeout)
 	defer cancel()
 	go Load(cancelCtx)
-	<-cancelCtx.Done()
+
+	select {
+	case <-fails.Fail():
+	case <-cancelCtx.Done():
+	}
 }

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -2,6 +2,7 @@ package scenario
 
 import (
 	"context"
+	"log"
 
 	"github.com/isucon10-qualify/isucon10-qualify/bench/client"
 	"github.com/isucon10-qualify/isucon10-qualify/bench/fails"
@@ -30,6 +31,7 @@ func Validation(ctx context.Context) {
 
 	select {
 	case <-fails.Fail():
+		log.Println("fail条件を満たしました")
 	case <-cancelCtx.Done():
 	}
 }


### PR DESCRIPTION
## 目的

- ベンチマーカーに余計な負荷をかけさせないため、 critical error が 1 個、または application error が 10 個発生した段階で即座にベンチマークを終了させる


## 動作確認

- [x] fail 条件を満たしたら、即座にベンチマークが fail することを確認

```

```

## 参考文献 (Optional)

- なし
