### PR TITLE
[bench] イス・物件の入稿前後での変化をcheckする

### DIFF
--- a/bench/client/newclient.go
+++ b/bench/client/newclient.go
@@ -70,3 +70,22 @@ func NewClientForVerify() *Client {
 		},
 	}
 }
+
+func NewClientForDraft() *Client {
+	return &Client{
+		userAgent: GenerateUserAgent(),
+		isBot:     false,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// HTTPのときには無視される
+					ServerName: ShareTargetURLs.TargetHost,
+				},
+			},
+			Timeout: parameter.DraftTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return fmt.Errorf("redirect attempted")
+			},
+		},
+	}
+}

--- a/bench/parameter/parameter.go
+++ b/bench/parameter/parameter.go
@@ -26,6 +26,7 @@ const (
 	DefaultAPITimeout              = 2000 * time.Millisecond
 	InitializeTimeout              = 30 * time.Second
 	VerifyTimeout                  = 10 * time.Second
+	DraftTimeout                   = 5 * time.Second
 	LoadTimeout                    = 60 * time.Second
 )
 

--- a/bench/scenario/load.go
+++ b/bench/scenario/load.go
@@ -138,7 +138,7 @@ func runBotWorker(ctx context.Context) {
 }
 
 func runChairDraftPostWorker(ctx context.Context) {
-	c := client.NewClient(false)
+	c := client.NewClientForDraft()
 
 	r := rand.Intn(parameter.SleepSwingBeforePostDraft) - parameter.SleepSwingBeforePostDraft*0.5
 	s := parameter.SleepBeforePostDraft + time.Duration(r)*time.Millisecond
@@ -157,7 +157,7 @@ func runChairDraftPostWorker(ctx context.Context) {
 }
 
 func runEstateDraftPostWorker(ctx context.Context) {
-	c := client.NewClient(false)
+	c := client.NewClientForDraft()
 
 	r := rand.Intn(parameter.SleepSwingBeforePostDraft) - parameter.SleepSwingBeforePostDraft*0.5
 	s := parameter.SleepBeforePostDraft + time.Duration(r)*time.Millisecond


### PR DESCRIPTION
## 目的

- 入稿 API について、チート行為として以下が考えられる
	- 入稿されるデータを事前に DB に入れておく
	- 受け取ったデータを DB に入れずに 201 を返す


## 解決方法

- イス・物件の入稿前後での変化をcheckする


## 動作確認

- [x] 高負荷状態で入稿がタイムアウトしないことを確認
- [x] 上記に挙げたチート行為ができないことを確認


## 参考文献 (Optional)

- なし
