### PR TITLE
[bench] 椅子の在庫数をcheckに失敗するバグを修正

### DIFF
--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -106,7 +106,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 				return failure.New(fails.ErrApplication)
 			}
 
-			if err := checkChairsOrderedByPopularity(cr.Chairs, t); err != nil {
+			if err := checkChairsOrderedByPopularity(_cr.Chairs, t); err != nil {
 				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
 				fails.Add(err, fails.ErrorOfChairSearchScenario)
 				return failure.New(fails.ErrApplication)


### PR DESCRIPTION
## 目的

- 椅子の在庫数の check が稀に失敗していた
- 椅子検索シナリオでは椅子検索を複数回行っていた
- その際に、在庫数チェックを最新の検索結果に対してではなく一つ前の有効な検索結果に対して行っていた


## 解決方法

- 最新の検索結果に対して在庫数の check を行うように修正


## 動作確認

- [x] 初期実装で椅子の在庫数の check が失敗しないことを確認


## 参考文献 (Optional)

- なし
