### PR TITLE
[bench] 存在しないイスへのSnapshot形式のVerifyが失敗するのを修正

### DIFF
--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -103,6 +103,14 @@ func verifyChairDetail(ctx context.Context, c *client.Client, filePath string) e
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
+	case http.StatusNotFound:
+		if actual != nil {
+			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
+		}
+		if err != nil {
+			return failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
+		}
+
 	default:
 		if err == nil {
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))


### PR DESCRIPTION
## 目的

- Fix #135 
- 存在しないイス・物件 (`id == 0`) への Snapshot 形式の Verify は故意に混ぜていた
- しかし、 `client.GetChairDetailFromID` は `http.StatusNotFound` の時に `nil, nil` を返す
- これのハンドリングが Snapshot 形式の Verify にて行われていなかったため、エラーが発生していた


## 解決方法

- イス詳細取得 API の Snapshot 形式の Verify に `http.StatusNotFound` のハンドリングを追加


## 動作確認

- [x] `GET /api/chair/0` への Snaphost 形式の Verify が fail しないことを確認


## 参考文献 (Optional)

- なし
