### PR TITLE
Fix: ベンチマーカーがレベル最大の時にout of indexで落ちるのを修正

### DIFF
--- a/bench/score/score.go
+++ b/bench/score/score.go
@@ -9,7 +9,7 @@ import (
 var (
 	score     int64 = 0
 	level     int64 = 0
-	maxLevel  int64 = int64(len(parameter.BoundaryOfLevel))
+	maxLevel  int64 = int64(len(parameter.BoundaryOfLevel)) - 1
 	levelChan chan int64
 	mu        sync.RWMutex
 )


### PR DESCRIPTION
## 目的

- レベルが最大の時に、ベンチがout-of-indexで落ちるのを修正


## 解決方法

- レベルの最大の値を修正した


## 動作確認

- [ ] (動作確認の方法、確認ができたらチェックボックスを埋める)


## 参考文献 (Optional)

- (参考にした記事などのURLを貼る)
