### PR TITLE
[bench] 物件の緯度・経度を比較しない

### DIFF
--- a/bench/asset/chair.go
+++ b/bench/asset/chair.go
@@ -7,12 +7,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"time"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
-
-var ignoreChairUnexported = cmpopts.IgnoreUnexported(Chair{})
 
 type JSONChair struct {
 	ID          int64  `json:"id"`
@@ -96,7 +91,17 @@ func (c *Chair) UnmarshalJSON(data []byte) error {
 }
 
 func (c1 *Chair) Equal(c2 *Chair) bool {
-	return cmp.Equal(c1, c2, ignoreChairUnexported)
+	return c1.ID == c2.ID &&
+		c1.Name == c2.Name &&
+		c1.Description == c2.Description &&
+		c1.Thumbnail == c2.Thumbnail &&
+		c1.Price == c2.Price &&
+		c1.Height == c2.Height &&
+		c1.Width == c2.Width &&
+		c1.Depth == c2.Depth &&
+		c1.Color == c2.Color &&
+		c1.Features == c2.Features &&
+		c1.Kind == c2.Kind
 }
 
 func (c *Chair) GetPopularity() int64 {

--- a/bench/asset/chair.go
+++ b/bench/asset/chair.go
@@ -7,7 +7,12 @@ import (
 	"strconv"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
+
+var ignoreChairUnexported = cmpopts.IgnoreUnexported(Chair{})
 
 type JSONChair struct {
 	ID          int64  `json:"id"`
@@ -91,17 +96,7 @@ func (c *Chair) UnmarshalJSON(data []byte) error {
 }
 
 func (c1 *Chair) Equal(c2 *Chair) bool {
-	return c1.ID == c2.ID &&
-		c1.Name == c2.Name &&
-		c1.Description == c2.Description &&
-		c1.Thumbnail == c2.Thumbnail &&
-		c1.Price == c2.Price &&
-		c1.Height == c2.Height &&
-		c1.Width == c2.Width &&
-		c1.Depth == c2.Depth &&
-		c1.Color == c2.Color &&
-		c1.Features == c2.Features &&
-		c1.Kind == c2.Kind
+	return cmp.Equal(c1, c2, ignoreChairUnexported)
 }
 
 func (c *Chair) GetPopularity() int64 {

--- a/bench/asset/estate.go
+++ b/bench/asset/estate.go
@@ -91,8 +91,6 @@ func (e1 *Estate) Equal(e2 *Estate) bool {
 		e1.Address == e2.Address &&
 		e1.DoorHeight == e2.DoorHeight &&
 		e1.DoorWidth == e2.DoorWidth &&
-		e1.Latitude == e2.Latitude &&
-		e1.Longitude == e2.Longitude &&
 		e1.Features == e2.Features
 }
 

--- a/bench/asset/estate.go
+++ b/bench/asset/estate.go
@@ -5,6 +5,14 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"strconv"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var (
+	ignoreEstateUnexported = cmpopts.IgnoreUnexported(Estate{})
+	allowFloatPointError   = cmpopts.EquateApprox(0, 0.00000000001)
 )
 
 type JSONEstate struct {
@@ -83,17 +91,7 @@ func (e *Estate) UnmarshalJSON(data []byte) error {
 }
 
 func (e1 *Estate) Equal(e2 *Estate) bool {
-	return e1.ID == e2.ID &&
-		e1.Name == e2.Name &&
-		e1.Description == e2.Description &&
-		e1.Thumbnail == e2.Thumbnail &&
-		e1.Rent == e2.Rent &&
-		e1.Address == e2.Address &&
-		e1.DoorHeight == e2.DoorHeight &&
-		e1.DoorWidth == e2.DoorWidth &&
-		e1.Latitude == e2.Latitude &&
-		e1.Longitude == e2.Longitude &&
-		e1.Features == e2.Features
+	return cmp.Equal(e1, e2, ignoreEstateUnexported, allowFloatPointError)
 }
 
 func (e *Estate) GetPopularity() int64 {

--- a/bench/asset/estate.go
+++ b/bench/asset/estate.go
@@ -5,14 +5,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"strconv"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-)
-
-var (
-	ignoreEstateUnexported = cmpopts.IgnoreUnexported(Estate{})
-	allowFloatPointError   = cmpopts.EquateApprox(0, 0.00000000001)
 )
 
 type JSONEstate struct {
@@ -91,7 +83,17 @@ func (e *Estate) UnmarshalJSON(data []byte) error {
 }
 
 func (e1 *Estate) Equal(e2 *Estate) bool {
-	return cmp.Equal(e1, e2, ignoreEstateUnexported, allowFloatPointError)
+	return e1.ID == e2.ID &&
+		e1.Name == e2.Name &&
+		e1.Description == e2.Description &&
+		e1.Thumbnail == e2.Thumbnail &&
+		e1.Rent == e2.Rent &&
+		e1.Address == e2.Address &&
+		e1.DoorHeight == e2.DoorHeight &&
+		e1.DoorWidth == e2.DoorWidth &&
+		e1.Latitude == e2.Latitude &&
+		e1.Longitude == e2.Longitude &&
+		e1.Features == e2.Features
 }
 
 func (e *Estate) GetPopularity() int64 {

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -38,6 +38,8 @@ const (
 var (
 	ignoreChairUnexported  = cmpopts.IgnoreUnexported(asset.Chair{})
 	ignoreEstateUnexported = cmpopts.IgnoreUnexported(asset.Estate{})
+	ignoreEstateLatitude   = cmpopts.IgnoreFields(asset.Estate{}, "Latitude")
+	ignoreEstateLongitude  = cmpopts.IgnoreFields(asset.Estate{}, "Longitude")
 )
 
 type Request struct {
@@ -219,8 +221,8 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -292,8 +294,8 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -360,8 +362,8 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -402,8 +404,8 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		if err != nil {
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -442,8 +444,8 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, ignoreEstateLatitude, ignoreEstateLongitude))
 			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -38,7 +38,6 @@ const (
 var (
 	ignoreChairUnexported  = cmpopts.IgnoreUnexported(asset.Chair{})
 	ignoreEstateUnexported = cmpopts.IgnoreUnexported(asset.Estate{})
-	allowFloatPointError   = cmpopts.EquateApprox(0, 0.00000000001)
 )
 
 type Request struct {
@@ -220,8 +219,8 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -293,8 +292,8 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -361,8 +360,8 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -403,8 +402,8 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		if err != nil {
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -443,8 +442,8 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
 			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -38,6 +38,7 @@ const (
 var (
 	ignoreChairUnexported  = cmpopts.IgnoreUnexported(asset.Chair{})
 	ignoreEstateUnexported = cmpopts.IgnoreUnexported(asset.Estate{})
+	allowFloatPointError   = cmpopts.EquateApprox(0, 0.00000000001)
 )
 
 type Request struct {
@@ -219,8 +220,8 @@ func verifyEstateDetail(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -292,8 +293,8 @@ func verifyEstateSearch(ctx context.Context, c *client.Client, filePath string) 
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -360,8 +361,8 @@ func verifyLowPricedEstate(ctx context.Context, c *client.Client, filePath strin
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -402,8 +403,8 @@ func verifyRecommendedEstateWithChair(ctx context.Context, c *client.Client, fil
 		if err != nil {
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
 			return failure.New(fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 
@@ -442,8 +443,8 @@ func verifyEstateNazotte(ctx context.Context, c *client.Client, filePath string)
 			return failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: SnapshotのResponse BodyのUnmarshalでエラーが発生しました"), failure.Messagef("snapshot: %s", filePath))
 		}
 
-		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported) {
-			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported))
+		if !cmp.Equal(*expected, *actual, ignoreEstateUnexported, allowFloatPointError) {
+			reporter.Logf("%s\n%s\n", filePath, cmp.Diff(*expected, *actual, ignoreEstateUnexported, allowFloatPointError))
 			return failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスが不正です"), failure.Messagef("snapshot: %s", filePath))
 		}
 


### PR DESCRIPTION
## 目的

- PHP にて、浮動小数点誤差による Application Error が発生していた

```diff
  asset.Estate{
        ... // 3 identical fields
        Description: "前日の夕方から始まった烈風交りの霙が、夜半�"...,
        Address:     "香川県文京区上野公園28丁目5番18号",
-       Latitude:    35.60790494879,
+       Latitude:    35.60790494879031,
-       Longitude:   135.98375267329,
+       Longitude:   135.98375267329175,
        DoorHeight:  60,
        DoorWidth:   152,
        ... // 1 ignored and 2 identical fields
  }
```

- `+` が PHP で、 DB には精度の高い方の値が格納されていた


## 解決方法

- 緯度・経度を比較しない


## 動作確認

- [x] PHP にて誤差による Application Error が発生しないことを確認


## 参考文献 (Optional)

- https://godoc.org/github.com/google/go-cmp/cmp/cmpopts#IgnoreFields
