### PR TITLE
[bench] エラーの発生場所を保持していたLabelを削除

### DIFF
--- a/bench/asset/asset.go
+++ b/bench/asset/asset.go
@@ -113,7 +113,7 @@ func Initialize(ctx context.Context, dataDir, fixtureDir string) {
 
 	if err := eg.Wait(); err != nil {
 		err = failure.Translate(err, fails.ErrBenchmarker, failure.Message("assetの初期化に失敗しました"))
-		fails.Add(err, fails.ErrorOfInitialize)
+		fails.Add(err)
 	}
 }
 

--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -50,7 +50,7 @@ func main() {
 	err := flags.Parse(os.Args[1:])
 	if err != nil {
 		err = failure.Translate(err, fails.ErrBenchmarker, failure.Message("コマンドライン引数のパースに失敗しました"))
-		fails.Add(err, fails.ErrorOfInitialize)
+		fails.Add(err)
 		reporter.SetPassed(false)
 		reporter.SetReason("コマンドライン引数のパースに失敗しました")
 		return
@@ -61,7 +61,7 @@ func main() {
 		conf.TargetHost,
 	)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrBenchmarker), fails.ErrorOfInitialize)
+		fails.Add(failure.Translate(err, fails.ErrBenchmarker))
 		reporter.SetPassed(false)
 		reporter.SetReason("ベンチ対象サーバーのURLが不正です")
 		return

--- a/bench/fails/fails.go
+++ b/bench/fails/fails.go
@@ -24,19 +24,6 @@ const (
 	ErrBot failure.StringCode = "error bot"
 )
 
-type ErrorLabel int
-
-const (
-	ErrorOfInitialize ErrorLabel = iota
-	ErrorOfVerify
-	ErrorOfEstateSearchScenario
-	ErrorOfChairSearchScenario
-	ErrorOfEstateNazotteSearchScenario
-	ErrorOfBotScenario
-	ErrorOfEstateDraftPostScenario
-	ErrorOfChairDraftPostScenario
-)
-
 var (
 	msgs []string
 
@@ -67,7 +54,7 @@ func Get() ([]string, int, int, int) {
 	return msgs[:], critical, application, trivial
 }
 
-func Add(err error, label ErrorLabel) {
+func Add(err error) {
 	if err == nil {
 		return
 	}

--- a/bench/scenario/botScenario.go
+++ b/bench/scenario/botScenario.go
@@ -18,14 +18,14 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q, err := createRandomChairSearchQuery()
 		if err != nil {
-			fails.Add(err, fails.ErrorOfBotScenario)
+			fails.Add(err)
 		}
 		q.Set("perPage", "10")
 		chairs, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
-				fails.Add(err, fails.ErrorOfBotScenario)
+				fails.Add(err)
 			}
 			return
 		}
@@ -37,7 +37,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 				_, err := c.GetChairDetailFromID(ctx, id)
 				code, _ := failure.CodeOf(err)
 				if code != fails.ErrBot {
-					fails.Add(err, fails.ErrorOfBotScenario)
+					fails.Add(err)
 				}
 			}(strconv.FormatInt(chair.ID, 10))
 		}
@@ -48,7 +48,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 		defer wg.Done()
 		q, err := createRandomEstateSearchQuery()
 		if err != nil {
-			fails.Add(err, fails.ErrorOfBotScenario)
+			fails.Add(err)
 		}
 		q.Set("perPage", "10")
 
@@ -56,7 +56,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 		if err != nil {
 			code, _ := failure.CodeOf(err)
 			if code != fails.ErrBot {
-				fails.Add(err, fails.ErrorOfBotScenario)
+				fails.Add(err)
 			}
 			return
 		}
@@ -68,7 +68,7 @@ func botScenario(ctx context.Context, c *client.Client) {
 				_, err := c.GetEstateDetailFromID(ctx, id)
 				code, _ := failure.CodeOf(err)
 				if code != fails.ErrBot {
-					fails.Add(err, fails.ErrorOfBotScenario)
+					fails.Add(err)
 				}
 			}(strconv.FormatInt(estate.ID, 10))
 		}

--- a/bench/scenario/chairDraftPostScenario.go
+++ b/bench/scenario/chairDraftPostScenario.go
@@ -42,38 +42,38 @@ func loadChairsFromJSON(ctx context.Context, filePath string) ([]asset.Chair, er
 func chairDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	chairs, err := loadChairsFromJSON(ctx, filePath)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 
 	id := strconv.FormatInt(chairs[0].ID, 10)
 	chair, err := c.GetChairDetailFromID(ctx, id)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 	if chair != nil {
-		fails.Add(failure.New(fails.ErrCritical, failure.Message("入稿前のイスが存在しています")), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.New(fails.ErrCritical, failure.Message("入稿前のイスが存在しています")))
 		return
 	}
 
 	err = c.PostChairs(ctx, chairs)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 
 	chair, err = c.GetChairDetailFromID(ctx, id)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 	if chair == nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿したイスのデータが不正です")), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿したイスのデータが不正です")))
 		return
 	}
 	if err := checkChairEqualToAsset(chair); err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿したイスのデータが不正です")), fails.ErrorOfChairDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿したイスのデータが不正です")))
 		return
 	}
 }

--- a/bench/scenario/chairSearchScenario.go
+++ b/bench/scenario/chairSearchScenario.go
@@ -18,19 +18,19 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -41,7 +41,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessChairSearchPage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -53,14 +53,14 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	for i := 0; i < parameter.NumOfSearchChairInScenario; i++ {
 		q, err := createRandomChairSearchQuery()
 		if err != nil {
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
 		t = time.Now()
 		_cr, err := c.SearchChairsWithQuery(ctx, q)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -74,7 +74,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkChairsOrderedByPopularity(_cr.Chairs, t); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -93,7 +93,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			t := time.Now()
 			_cr, err := c.SearchChairsWithQuery(ctx, q)
 			if err != nil {
-				fails.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -102,13 +102,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if len(_cr.Chairs) == 0 {
-				fails.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
 			if err := checkChairsOrderedByPopularity(_cr.Chairs, t); err != nil {
 				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/search: レスポンスの内容が不正です"))
-				fails.Add(err, fails.ErrorOfChairSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -138,7 +138,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		chair, er, err = c.AccessChairDetailPage(ctx, targetID)
 
 		if err != nil {
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -152,13 +152,13 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkChairEqualToAsset(chair); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/:id: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
 		if err := checkRecommendedEstates(er.Estates, chair); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/recommended_estate/:id: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -171,7 +171,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.BuyChair(ctx, strconv.FormatInt(targetID, 10))
 	if err != nil {
 		if _chair, err := asset.GetChairFromID(targetID); err != nil || _chair.GetStock() > 0 {
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -184,7 +184,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 		t = time.Now()
 		e, err := c.AccessEstateDetailPage(ctx, targetID)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -194,7 +194,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkEstateEqualToAsset(e); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfChairSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -207,7 +207,7 @@ func chairSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 
 	if err != nil {
-		fails.Add(err, fails.ErrorOfChairSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/estateDraftPostScenario.go
+++ b/bench/scenario/estateDraftPostScenario.go
@@ -42,28 +42,28 @@ func loadEstatesFromJSON(ctx context.Context, filePath string) ([]asset.Estate, 
 func estateDraftPostScenario(ctx context.Context, c *client.Client, filePath string) {
 	estates, err := loadEstatesFromJSON(ctx, filePath)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 	}
 
 	id := strconv.FormatInt(estates[0].ID, 10)
 	estate, _ := c.GetEstateDetailFromID(ctx, id)
 	if estate != nil {
-		fails.Add(failure.New(fails.ErrCritical, failure.Message("入稿前の物件が存在しています")), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.New(fails.ErrCritical, failure.Message("入稿前の物件が存在しています")))
 		return
 	}
 
 	err = c.PostEstates(ctx, estates)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 
 	estate, err = c.GetEstateDetailFromID(ctx, id)
 	if err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical))
 		return
 	}
 	if err := checkEstateEqualToAsset(estate); err != nil {
-		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿した物件のデータが不正です")), fails.ErrorOfEstateDraftPostScenario)
+		fails.Add(failure.Translate(err, fails.ErrCritical, failure.Message("入稿した物件のデータが不正です")))
 	}
 }

--- a/bench/scenario/estateNazotteSearchScenario.go
+++ b/bench/scenario/estateNazotteSearchScenario.go
@@ -174,19 +174,19 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -197,7 +197,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessEstateNazottePage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -213,7 +213,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	er, err := c.SearchEstatesNazotte(ctx, polygon)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -223,13 +223,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 
 	if len(er.Estates) > parameter.MaxLengthOfNazotteResponse {
 		err = failure.New(fails.ErrApplication, failure.Message("POST /api/estate/nazotte: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesInBoundingBox(er.Estates, boundingBox); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/nazotte: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -242,7 +242,7 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	e, err := c.AccessEstateDetailPage(ctx, targetID)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -253,13 +253,13 @@ func estateNazotteSearchScenario(ctx context.Context, c *client.Client) error {
 	estate, err := asset.GetEstateFromID(e.ID)
 	if err != nil || !e.Equal(estate) {
 		err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateNazotteSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/estateSearchScenario.go
+++ b/bench/scenario/estateSearchScenario.go
@@ -19,19 +19,19 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	t := time.Now()
 	chairs, estates, err := c.AccessTopPage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkChairsOrderedByPrice(chairs.Chairs, t); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/chair/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
 	if err := checkEstatesOrderedByRent(estates.Estates); err != nil {
 		err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/low_priced: レスポンスの内容が不正です"))
-		fails.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 
@@ -42,7 +42,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	t = time.Now()
 	err = c.AccessEstateSearchPage(ctx)
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 	if time.Since(t) > parameter.ThresholdTimeOfAbandonmentPage {
@@ -54,14 +54,14 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	for i := 0; i < parameter.NumOfSearchEstateInScenario; i++ {
 		q, err := createRandomEstateSearchQuery()
 		if err != nil {
-			fails.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
 		t = time.Now()
 		_er, err := c.SearchEstatesWithQuery(ctx, q)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -75,7 +75,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 
 		if err := checkEstatesOrderedByPopularity(_er.Estates); err != nil {
 			err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -95,7 +95,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			t := time.Now()
 			_er, err := c.SearchEstatesWithQuery(ctx, q)
 			if err != nil {
-				fails.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -104,13 +104,13 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 			}
 
 			if len(_er.Estates) == 0 {
-				fails.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
 			if err := checkEstatesOrderedByPopularity(er.Estates); err != nil {
 				err = failure.Translate(err, fails.ErrApplication, failure.Message("GET /api/estate/search: レスポンスの内容が不正です"))
-				fails.Add(err, fails.ErrorOfEstateSearchScenario)
+				fails.Add(err)
 				return failure.New(fails.ErrApplication)
 			}
 
@@ -137,7 +137,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		t = time.Now()
 		e, err := c.AccessEstateDetailPage(ctx, targetID)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 
@@ -148,7 +148,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 		estate, err := asset.GetEstateFromID(e.ID)
 		if err != nil || !e.Equal(estate) {
 			err = failure.New(fails.ErrApplication, failure.Message("GET /api/estate/:id: レスポンスの内容が不正です"))
-			fails.Add(err, fails.ErrorOfEstateSearchScenario)
+			fails.Add(err)
 			return failure.New(fails.ErrApplication)
 		}
 	}
@@ -160,7 +160,7 @@ func estateSearchScenario(ctx context.Context, c *client.Client) error {
 	err = c.RequestEstateDocument(ctx, strconv.FormatInt(targetID, 10))
 
 	if err != nil {
-		fails.Add(err, fails.ErrorOfEstateSearchScenario)
+		fails.Add(err)
 		return failure.New(fails.ErrApplication)
 	}
 

--- a/bench/scenario/scenario.go
+++ b/bench/scenario/scenario.go
@@ -21,9 +21,9 @@ func Initialize(ctx context.Context) *client.InitializeResponse {
 	if err != nil {
 		if ctx.Err() != nil {
 			err = failure.New(fails.ErrCritical, failure.Message("POST /initialize: リクエストがタイムアウトしました"))
-			fails.Add(err, fails.ErrorOfInitialize)
+			fails.Add(err)
 		} else {
-			fails.Add(err, fails.ErrorOfInitialize)
+			fails.Add(err)
 		}
 	}
 	return res

--- a/bench/scenario/verify.go
+++ b/bench/scenario/verify.go
@@ -39,13 +39,13 @@ func Verify(ctx context.Context, dataDir, fixtureDir string) {
 	verifyWithSnapshot(ctx, c, filepath.Join(dataDir, "result/verification_data"))
 	if ctx.Err() != nil {
 		err := failure.New(fails.ErrCritical, failure.Message("アプリケーション互換性チェックがタイムアウトしました"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	}
 
 	verifyWithScenario(ctx, c, fixtureDir, dataDir)
 	if ctx.Err() != nil {
 		err := failure.New(fails.ErrCritical, failure.Message("アプリケーション互換性チェックがタイムアウトしました"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	}
 
 	cancel()
@@ -177,7 +177,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 	})
 
 	if err := eg.Wait(); err != nil {
-		fails.Add(failure.Translate(err, fails.ErrBenchmarker), fails.ErrorOfVerify)
+		fails.Add(failure.Translate(err, fails.ErrBenchmarker))
 		return
 	}
 
@@ -187,7 +187,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 		defer wg.Done()
 		err := verifyPostEstates(ctx, c, estates)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfVerify)
+			fails.Add(err)
 		}
 	}()
 
@@ -196,7 +196,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 		defer wg.Done()
 		err := verifyPostChairs(ctx, c, chairs)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfVerify)
+			fails.Add(err)
 		}
 	}()
 
@@ -207,7 +207,7 @@ func verifyWithScenario(ctx context.Context, c *client.Client, fixtureDir, snaps
 		defer wg.Done()
 		err := verifyChairStock(ctx, c, chairs[0].ID)
 		if err != nil {
-			fails.Add(err, fails.ErrorOfVerify)
+			fails.Add(err)
 		}
 	}()
 

--- a/bench/scenario/verifyWithSnapshot.go
+++ b/bench/scenario/verifyWithSnapshot.go
@@ -465,7 +465,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err := ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/:id: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyChairDetail; i++ {
 			wg.Add(1)
@@ -473,7 +473,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairDetail(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -484,7 +484,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search/condition: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyChairSearchCondition; i++ {
 			wg.Add(1)
@@ -492,7 +492,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairSearchCondition(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -503,7 +503,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/search: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyChairSearch; i++ {
 			wg.Add(1)
@@ -511,7 +511,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyChairSearch(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -522,7 +522,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/:id: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyEstateDetail; i++ {
 			wg.Add(1)
@@ -530,7 +530,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateDetail(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -541,7 +541,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search/condition: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyEstateSearchCondition; i++ {
 			wg.Add(1)
@@ -549,7 +549,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateSearchCondition(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -560,7 +560,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/search: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyEstateSearch; i++ {
 			wg.Add(1)
@@ -568,7 +568,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateSearch(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -579,7 +579,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/chair/low_priced: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyLowPricedChair; i++ {
 			wg.Add(1)
@@ -587,7 +587,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyLowPricedChair(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -598,7 +598,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/estate/low_priced: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyLowPricedEstate; i++ {
 			wg.Add(1)
@@ -606,7 +606,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyLowPricedEstate(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -617,7 +617,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("GET /api/recommended_estate/:id: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyRecommendedEstateWithChair; i++ {
 			wg.Add(1)
@@ -625,7 +625,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyRecommendedEstateWithChair(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))
@@ -636,7 +636,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 	snapshots, err = ioutil.ReadDir(snapshotsDirPath)
 	if err != nil {
 		err := failure.Translate(err, fails.ErrBenchmarker, failure.Message("POST /api/estate/nazotte: Snapshotディレクトリがありません"))
-		fails.Add(err, fails.ErrorOfVerify)
+		fails.Add(err)
 	} else {
 		for i := 0; i < NumOfVerifyEstateNazotte; i++ {
 			wg.Add(1)
@@ -644,7 +644,7 @@ func verifyWithSnapshot(ctx context.Context, c *client.Client, snapshotsParentsD
 			go func(filePath string) {
 				err := verifyEstateNazotte(ctx, c, filePath)
 				if err != nil {
-					fails.Add(err, fails.ErrorOfVerify)
+					fails.Add(err)
 				}
 				wg.Done()
 			}(path.Join(snapshotsDirPath, snapshots[r].Name()))


### PR DESCRIPTION
## 目的

- https://github.com/isucon10-qualify/isucon10-qualify/pull/90 から追加されていた `ErrorLabel` が、 https://github.com/isucon/isucon10-qualify/pull/124 によって不要になった


## 解決方法

- `ErrorLabel` を削除


## 動作確認

- [x] Go の初期実装でベンチマークが正常に終了することを確認


## 参考文献 (Optional)

- なし
