### PR TITLE
Revert "[bench] ベンチマーク実行中にpanicが起きたらrecoverしてreportする"

### DIFF
--- a/bench/cmd/bench/bench.go
+++ b/bench/cmd/bench/bench.go
@@ -35,14 +35,6 @@ func main() {
 		reporter.Report(fails.Get())
 	}()
 
-	defer func() {
-		err := recover()
-		if err, ok := err.(error); ok {
-			err = failure.Translate(err, fails.ErrBenchmarker)
-			fails.Add(err)
-		}
-	}()
-
 	flags := flag.NewFlagSet("isucon10-qualify", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
 


### PR DESCRIPTION
Reverts isucon/isucon10-qualify#163

予選の段階で入っていなかったため、予選で提供した状態を維持するために revert